### PR TITLE
DAF memo style, letterhead updates, and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,6 @@ All notable changes to `tonguetoquill-usaf-memo` are documented here.
 
 ---
 
-## Unreleased
-
-### Removed
-
-- **`auto_numbering` frontmatter parameter.** Base-level paragraphs are never numbered automatically. Hierarchical AFH-style numbering applies only to explicit `#list` / `#enum` items (same as the former `auto_numbering: false` behavior). Remove `auto_numbering: ...` from `frontmatter.with(...)` calls.
-
----
-
 ## [2.0.0] — 2026-03-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `tonguetoquill-usaf-memo` are documented here.
 
 ---
 
+## Unreleased
+
+### Removed
+
+- **`auto_numbering` frontmatter parameter.** Base-level paragraphs are never numbered automatically. Hierarchical AFH-style numbering applies only to explicit `#list` / `#enum` items (same as the former `auto_numbering: false` behavior). Remove `auto_numbering: ...` from `frontmatter.with(...)` calls.
+
+---
+
 ## [2.0.0] — 2026-03-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -220,9 +220,6 @@ Configures the memorandum header and establishes document-wide settings. Applied
   // Classification and branding
   classification_level: none,                               // "UNCLASSIFIED", "CONFIDENTIAL", "SECRET", or "TOP SECRET"
   footer_tag_line: none,                                    // Custom footer tagline (e.g., "semper supra")
-
-  // Paragraph numbering
-  auto_numbering: true,                                     // Automatic AFH 33-337 paragraph numbering (default true)
 )
 ```
 
@@ -237,17 +234,16 @@ Configures the memorandum header and establishes document-wide settings. Applied
 
 #### `mainmatter`
 
-Processes the memorandum body content with automatic paragraph numbering. Applied as a show rule with no parameters.
+Processes the memorandum body content. Base-level paragraphs are unnumbered; use list/enum for hierarchical subparagraph numbering. Applied as a show rule with no parameters.
 
 ```typst
 #show: mainmatter
 ```
 
 **Responsibilities:**
-- Applies AFH 33-337 hierarchical paragraph numbering (1., a., (1), (a))
+- Applies AFH 33-337 hierarchical numbering (1., a., (1), (a)) to explicit list/enum items
+- Renders base-level paragraphs flush left without numbers
 - Handles proper indentation and spacing
-- Auto-detects single vs. multiple paragraphs
-- When `auto_numbering: false` is set in `frontmatter`, base-level paragraphs render flush left without numbering; only explicitly bulleted or numbered items (list/enum) receive numbering
 - Supports inline tables with formal black-border formatting
 - Inherits configuration from frontmatter
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ Configures the memorandum header and establishes document-wide settings. Applied
   // Classification and branding
   classification_level: none,                               // "UNCLASSIFIED", "CONFIDENTIAL", "SECRET", or "TOP SECRET"
   footer_tag_line: none,                                    // Custom footer tagline (e.g., "semper supra")
+
+  // Paragraph numbering
+  auto_numbering: true,                                     // Automatic AFH 33-337 paragraph numbering (default true)
 )
 ```
 
@@ -234,16 +237,17 @@ Configures the memorandum header and establishes document-wide settings. Applied
 
 #### `mainmatter`
 
-Processes the memorandum body content. Base-level paragraphs are unnumbered; use list/enum for hierarchical subparagraph numbering. Applied as a show rule with no parameters.
+Processes the memorandum body content with automatic paragraph numbering. Applied as a show rule with no parameters.
 
 ```typst
 #show: mainmatter
 ```
 
 **Responsibilities:**
-- Applies AFH 33-337 hierarchical numbering (1., a., (1), (a)) to explicit list/enum items
-- Renders base-level paragraphs flush left without numbers
+- Applies AFH 33-337 hierarchical paragraph numbering (1., a., (1), (a))
 - Handles proper indentation and spacing
+- Auto-detects single vs. multiple paragraphs
+- When `auto_numbering: false` is set in `frontmatter`, base-level paragraphs render flush left without numbering; only explicitly bulleted or numbered items (list/enum) receive numbering
 - Supports inline tables with formal black-border formatting
 - Inherits configuration from frontmatter
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Configures the memorandum header and establishes document-wide settings. Applied
   letterhead_title: "DEPARTMENT OF THE AIR FORCE",           // Organization title
   letterhead_caption: "[YOUR SQUADRON/UNIT NAME]",           // Sub-organization
   letterhead_seal: none,                                     // Organization seal image
+  letterhead_seal_subtitle: none,                            // Optional line under seal (9pt bold caps)
   date: none,                                                // Date (defaults to today; also accepts ISO string "YYYY-MM-DD")
   memo_for: ("[OFFICE1]", "[OFFICE2]"),                     // Recipients array
   memo_from: ("[YOUR/SYMBOL]", "[Organization]", "[Address]"), // Sender info array
@@ -228,7 +229,7 @@ Configures the memorandum header and establishes document-wide settings. Applied
 
 **Responsibilities:**
 - Sets page layout with 1-inch margins
-- Renders letterhead with optional seal
+- Renders letterhead with optional seal and optional `letterhead_seal_subtitle` under the seal
 - Renders date, MEMORANDUM FOR, FROM, SUBJECT, and references sections
 - Establishes typography and spacing rules
 - Renders color-coded classification banners in header and footer when `classification_level` is set

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Maintained by [TTQ](https://www.tonguetoquill.com).
 - **Page numbering** starting from page 2 per AFH 33-337 standards
 - **Highly Configurable** with numerous parameters for customization
 - **Comprehensive Indorsements** with full support for action lines, multiple indorsement types, and long indorsement chains
-- **Classification markings** with color-coded header/footer banners (UNCLASSIFIED, CONFIDENTIAL, SECRET, TOP SECRET)
+- **Classification markings** with color-coded header/footer banners for UNCLASSIFIED, SECRET, and TOP SECRET (other banner text uses the default color)
 - **Custom footer taglines** for service-specific branding (e.g., "semper supra" for Space Force)
 - **Inline tables** with clean, formal formatting consistent with USAF correspondence standards
 
@@ -180,7 +180,7 @@ Set `classification_level` in `frontmatter` to display color-coded banners in th
 )
 ```
 
-Supported levels and their colors: `"UNCLASSIFIED"` (green), `"CONFIDENTIAL"` (blue), `"SECRET"` (red), `"TOP SECRET"` (orange). The banner text is rendered in bold at the top and bottom center of every page.
+Banner color applies when the marking string (after trimming) begins with `"UNCLASSIFIED"` (green), `"SECRET"` (red), or `"TOP SECRET"` (orange). Any other text still appears in bold in the header and footer but uses the default text color (black). Placement is top and bottom center of every page.
 
 ## API Reference
 
@@ -217,7 +217,7 @@ Configures the memorandum header and establishes document-wide settings. Applied
   memo_for_cols: 3,                                         // Recipient columns
 
   // Classification and branding
-  classification_level: none,                               // "UNCLASSIFIED", "CONFIDENTIAL", "SECRET", or "TOP SECRET"
+  classification_level: none,                               // e.g. "UNCLASSIFIED", "SECRET", or "TOP SECRET" for standard colors
   footer_tag_line: none,                                    // Custom footer tagline (e.g., "semper supra")
 
   // Paragraph numbering

--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ Maintained by [TTQ](https://www.tonguetoquill.com).
 
 1. Go to [the package page](https://typst.app/universe/package/tonguetoquill-usaf-memo) and click "Create project in app".
 
-2. Download the project fonts and upload them to your project folder. The template uses multiple open-source fonts — not just Copperplate. Recommended fonts from the `fonts/` directory are:
+2. Download the project fonts and upload them to your project folder. Recommended fonts from the `fonts/` directory are:
 
-- `CopperplateCC-Heavy.otf` — letterhead / heading style (open-source Copperplate clone)
-- `NimbusRomNo9L-Reg.otf`, `NimbusRomNo9L-RegIta.otf`, `NimbusRomNo9L-Med.otf`, `NimbusRomNo9L-MedIta.otf` — body / serif text (open-source Times clone)
-- `Cinzel-Regular.ttf` — optional monospace font
+- `NimbusRomNo9L-Reg.otf`, `NimbusRomNo9L-RegIta.otf`, `NimbusRomNo9L-Med.otf`, `NimbusRomNo9L-MedIta.otf` — letterhead and body text (open-source Times New Roman–compatible serif)
+- `Cinzel-Regular.ttf` — optional decorative font for footer taglines
 
 You can either clone the repository to pull all fonts or download just the files you need. All font files are available from the `fonts/` directory in the repo: https://github.com/nibsbin/tonguetoquill-usaf-memo/tree/main/fonts
 
@@ -60,7 +59,6 @@ cd my-memo
 3. Download the required fonts:
 ```bash
 # Download the fonts used by the templates (example). Copy these into your project root or `fonts/` directory.
-curl -L -o CopperplateCC-Heavy.otf https://github.com/nibsbin/tonguetoquill-usaf-memo/raw/main/fonts/CopperplateCC/CopperplateCC-Heavy.otf
 curl -L -o Cinzel-Regular.ttf https://github.com/nibsbin/tonguetoquill-usaf-memo/raw/main/fonts/Cinzel/Cinzel-Regular.ttf
 curl -L -o NimbusRomNo9L-Reg.otf https://github.com/nibsbin/tonguetoquill-usaf-memo/raw/main/fonts/NimbusRomanNo9L/NimbusRomNo9L-Reg.otf
 curl -L -o NimbusRomNo9L-RegIta.otf https://github.com/nibsbin/tonguetoquill-usaf-memo/raw/main/fonts/NimbusRomanNo9L/NimbusRomNo9L-RegIta.otf
@@ -213,7 +211,7 @@ Configures the memorandum header and establishes document-wide settings. Applied
   references: ("AFI 123-45", "AFMAN 67-89"),                // Optional references
 
   // Styling options
-  letterhead_font: ("Copperplate CC",),                     // Letterhead fonts
+  letterhead_font: ("times new roman", "NimbusRomNo9L"),   // Letterhead fonts (defaults match body)
   body_font: ("times new roman", "NimbusRomNo9L"),          // Body fonts
   font_size: 12pt,                                          // Font size (default 12pt; 10pt minimum per AFH 33-337 §5)
   memo_for_cols: 3,                                         // Recipient columns
@@ -346,5 +344,4 @@ External assets used in this project:
 
 - `dow_seal.png` is [public domain](https://www.e-publishing.af.mil/Portals/1/Documents/Official%20Memorandum%20Template_10Nov2020.dotx?ver=M7cny_cp1_QDajkyg0xWBw%3D%3D)
 - `starkindustries_seal.png` is [public domain](https://commons.wikimedia.org/wiki/File:Stark_Industries.png).
-- `Copperplate CC` is under [SIL Open Font License](./fonts/CopperplateCC/LICENSE.md) pulled from [here](https://github.com/CowboyCollective/CopperplateCC)
 - `NimbusRomNo9L` is under [GPL](./fonts/NimbusRomanNo9L/GNU%20General%20Public%20License.txt) pulled from URW++ foundry

--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,7 @@ echo
 compile_template "starkindustries"
 compile_template "usaf-template"
 compile_template "ussf-template"
+compile_template "daf-template"
 
 echo
 echo "All compilations completed."

--- a/prose/designs/INDEX.md
+++ b/prose/designs/INDEX.md
@@ -4,6 +4,7 @@
 
 | Design | One-liner |
 |--------|-----------|
+| [DAF Memo Style](daf-memo-style.md) | Add `memo_style` enum with DAF paragraph rules |
 | [Indorsement Approval Action](indorsement-approval-action.md) | Approve/Disapprove rendering on indorsement memos |
 
 ## Archived Designs

--- a/prose/designs/daf-memo-style.md
+++ b/prose/designs/daf-memo-style.md
@@ -1,0 +1,94 @@
+# DAF Memo Style
+
+**Status:** Implemented
+
+## TL;DR
+
+Add a `memo_style` enum to `frontmatter()` with values `"usaf"` and `"daf"`. The default `"usaf"` preserves current behavior. `"daf"` changes paragraph rendering to:
+
+- Top-level body paragraphs are unnumbered and first-line indented by `0.5in`
+- First nested paragraph level starts at level 2 formatting (`"a."`, `"b."`, ...)
+- Each deeper nested level increases indentation by another `0.5in`
+
+## Problem
+
+The template currently implements AFH 33-337-centric paragraph handling where top-level paragraphs are numbered (`1.`, `2.`, ...), and nested indentation is computed from measured ancestor label widths.
+
+For DAF memo style, paragraph behavior differs:
+
+1. Do not automatically number top-level paragraphs
+2. Indent the first line of each top-level paragraph by `0.5in`
+3. Start the first nested paragraph at the alpha level (`a.`, `b.`, `c.`)
+4. Increase nesting indentation by fixed `0.5in` increments
+
+## Design
+
+### API Surface
+
+`frontmatter()` now accepts:
+
+```typst
+memo_style: "usaf" // or "daf"
+```
+
+Validation is strict:
+
+```typst
+assert(memo_style in ("usaf", "daf"), message: "memo_style must be \"usaf\" or \"daf\"")
+```
+
+The value is stored in document metadata and consumed by body renderers:
+
+- `mainmatter()` reads metadata and forwards `memo_style` to `render-body()`
+- `indorsement()` reads metadata and forwards `memo_style` to `render-body()`
+
+### Rendering Rules by Style
+
+| Behavior | `"usaf"` | `"daf"` |
+|----------|----------|---------|
+| Top-level paragraph numbering | Enabled by existing `auto_numbering` logic | Disabled |
+| Top-level paragraph indent | Flush left | First-line indent `0.5in` |
+| First nested numbered level | Existing hierarchy (`a.` after top-level) | Starts at `a.` |
+| Nested indentation basis | Measured width of ancestor labels | Fixed `0.5in` per nesting depth |
+
+For `"daf"`, `auto_numbering` is ignored for body paragraph decisions because style rules fully define numbering/indent behavior.
+
+### DAF Body Mechanics
+
+`render-body()` adds style-aware branch logic:
+
+- Top-level (`nest_level == 0`): render `[ #h(0.5in)#body ]` (no number)
+- Nested (`nest_level > 0`): render numbered paragraph using format index = `nest_level`
+  - `nest_level = 1` -> `"a."`
+  - `nest_level = 2` -> `"(1)"`
+  - `nest_level = 3` -> `"(a)"`
+- Continuations: align text after current level label width, with fixed base indent
+- Counter resets: on any top-level paragraph, reset nested counters so later nested sequences restart predictably
+
+### Configuration Placement
+
+No duplicate constants are introduced outside `config.typ`; DAF-specific behavior is implemented as rendering logic in `body.typ`, keeping static config centralized and behavior localized to the body formatter.
+
+## Backward Compatibility
+
+- Existing documents are unchanged (`memo_style` defaults to `"usaf"`)
+- Existing `auto_numbering: false` behavior remains for `"usaf"`
+- Indorsements inherit memo style via existing metadata flow
+
+## Example
+
+```typst
+#show: frontmatter.with(
+  memo_style: "daf",
+  subject: "DAF Memo Example",
+  memo_for: ("ORG/SYMBOL",),
+  memo_from: ("ORG/SYMBOL",),
+)
+
+#show: mainmatter
+
+Top-level paragraph text (indented 0.5in, unnumbered).
+
++ First nested item (renders as a.)
++ Second nested item (renders as b.)
+```

--- a/src/body.typ
+++ b/src/body.typ
@@ -96,10 +96,8 @@
 
 /// Calculates fixed indentation for DAF paragraph levels.
 ///
-/// DAF style uses fixed 0.5in indentation steps per nesting level.
-/// - Level 1: 0.5in
-/// - Level 2: 1.0in
-/// - Level N: N * 0.5in
+/// Top-level body uses `daf-paragraph.top-first-line-indent` (0.5in). First nested
+/// level uses `nested-first-level-indent` (1in); deeper levels add `nested-step`.
 ///
 /// - level (int): Paragraph nesting level (0-based)
 /// -> length
@@ -107,12 +105,12 @@
   if level <= 0 {
     return 0pt
   }
-  level * 0.5in
+  daf-paragraph.nested-first-level-indent + (level - 1) * daf-paragraph.nested-step
 }
 
 /// Formats a DAF nested paragraph with fixed indentation and numbering.
 ///
-/// DAF nested items begin at level 1 ("a.") and indent by fixed 0.5in per level.
+/// DAF nested items begin at level 1 ("a.") at 1in, then 0.5in more per level.
 ///
 /// - body (content): Paragraph content to format
 /// - level (int): Paragraph nesting level (0-based)
@@ -338,7 +336,7 @@
             for child in range(max-levels) {
               level-counts.insert(str(child), 1)
             }
-            [#h(0.5in)#item_content]
+            [#h(daf-paragraph.top-first-line-indent)#item_content]
           }
         } else if auto-numbering {
           if par_count > 1 {

--- a/src/body.typ
+++ b/src/body.typ
@@ -13,29 +13,13 @@
 
 /// Gets the numbering format for a specific paragraph level.
 ///
-/// AFH 33-337 "The Text of the Official Memorandum" §2: "Number and letter each
-/// paragraph and subparagraph" with hierarchical numbering implied by examples.
-/// Standard military format follows the pattern: 1., a., (1), (a), etc.
-///
-/// Returns the appropriate numbering format for AFH 33-337 compliant
-/// hierarchical paragraph numbering:
-/// - Level 0: "1." (1., 2., 3., etc.)
-/// - Level 1: "a." (a., b., c., etc.)
-/// - Level 2: "(1)" ((1), (2), (3), etc.)
-/// - Level 3: "(a)" ((a), (b), (c), etc.)
-/// - Level 4+: Underlined format for deeper nesting
-///
 /// - level (int): Paragraph nesting level (0-based)
 /// -> str | function
 #let get-paragraph-numbering-format(level) = {
   paragraph-config.numbering-formats.at(level, default: "i.")
 }
 
-/// Calculates indentation width using explicit counter values.
-///
-/// Computes the exact indentation needed for hierarchical paragraph alignment
-/// by measuring the cumulative width of all ancestor paragraph numbers and their
-/// spacing. Uses the provided counter values directly (no Typst counter reads).
+/// Calculates indentation for USAF-style paragraphs from explicit counter values.
 ///
 /// - level (int): Paragraph nesting level (0-based)
 /// - level-counts (dictionary): Maps level index strings to their current counter values
@@ -49,55 +33,15 @@
     let ancestor-value = level-counts.at(str(ancestor-level), default: 1)
     let ancestor-format = get-paragraph-numbering-format(ancestor-level)
     let ancestor-number = numbering(ancestor-format, ancestor-value)
-    let width = measure([#ancestor-number#"  "]).width
-    total-indent += width
+    total-indent += measure([#ancestor-number#"  "]).width
   }
   total-indent
 }
 
-/// Formats a numbered paragraph with proper indentation.
-///
-/// Generates a properly formatted paragraph with AFH 33-337 compliant numbering
-/// and indentation. Uses explicit level and counter values to avoid nested-context
-/// state propagation issues.
-///
-/// - body (content): Paragraph content to format
-/// - level (int): Paragraph nesting level (0-based)
-/// - level-counts (dictionary): Current counter values per level
-/// -> content
-#let format-numbered-par(body, level, level-counts) = {
-  let current-value = level-counts.at(str(level), default: 1)
-  let format = get-paragraph-numbering-format(level)
-  let number-text = numbering(format, current-value)
-  let indent-width = calculate-indent-from-counts(level, level-counts)
-  [#h(indent-width)#number-text#"  "#body]
-}
-
-/// Formats a continuation paragraph within a multi-block list item.
-///
-/// Renders a paragraph that belongs to the same list item as the preceding
-/// numbered paragraph. The text is indented to align with the first character
-/// of the preceding numbered paragraph's text (past the number and spacing),
-/// but no new number is generated.
-///
-/// - body (content): Continuation paragraph content to format
-/// - level (int): Paragraph nesting level (0-based)
-/// - level-counts (dictionary): Current counter values per level
-/// -> content
-#let format-continuation-par(body, level, level-counts) = {
-  let indent-width = calculate-indent-from-counts(level, level-counts)
-  // Add the width of the current level's number + spacing to align with text
-  let current-value = level-counts.at(str(level), default: 1)
-  let format = get-paragraph-numbering-format(level)
-  let number-text = numbering(format, current-value)
-  let number-width = measure([#number-text#"  "]).width
-  [#h(indent-width + number-width)#body]
-}
-
 /// Calculates fixed indentation for DAF paragraph levels.
 ///
-/// Top-level body uses `daf-paragraph.top-first-line-indent` (0.5in). First nested
-/// level uses `nested-first-level-indent` (1in); deeper levels add `nested-step`.
+/// First nested level starts at `nested-first-level-indent` (1in); deeper levels
+/// add `nested-step` (0.5in) per additional depth.
 ///
 /// - level (int): Paragraph nesting level (0-based)
 /// -> length
@@ -108,38 +52,33 @@
   daf-paragraph.nested-first-level-indent + (level - 1) * daf-paragraph.nested-step
 }
 
-/// Formats a DAF nested paragraph with fixed indentation and numbering.
-///
-/// DAF nested items begin at level 1 ("a.") at 1in, then 0.5in more per level.
-///
-/// - body (content): Paragraph content to format
-/// - level (int): Paragraph nesting level (0-based)
-/// - level-counts (dictionary): Current counter values per level
-/// -> content
-#let format-daf-par(body, level, level-counts) = {
-  let current-value = level-counts.at(str(level), default: 1)
-  let format = get-paragraph-numbering-format(level)
-  let number-text = numbering(format, current-value)
-  let indent-width = calculate-daf-indent(level)
-  [#h(indent-width)#number-text#"  "#body]
+/// Resets counter entries from `start` upward to 1 in the level-counts dictionary.
+#let reset-levels-from(level-counts, start, max-levels) = {
+  for child in range(start, max-levels) {
+    level-counts.insert(str(child), 1)
+  }
+  level-counts
 }
 
-/// Formats a DAF continuation paragraph with fixed indentation.
+/// Formats a paragraph (or continuation) with a given indent strategy.
 ///
-/// Continuation lines align with the first text character after the numbered
-/// label for the current nested level.
-///
-/// - body (content): Continuation paragraph content to format
-/// - level (int): Paragraph nesting level (0-based)
+/// - body (content): Paragraph content
+/// - level (int): Nesting level (0-based)
 /// - level-counts (dictionary): Current counter values per level
+/// - indent-fn (function): `(level, level-counts) -> length`
+/// - continuation (bool): If true, adds number-label width to alignment
 /// -> content
-#let format-daf-continuation-par(body, level, level-counts) = {
-  let indent-width = calculate-daf-indent(level)
-  let current-value = level-counts.at(str(level), default: 1)
-  let format = get-paragraph-numbering-format(level)
-  let number-text = numbering(format, current-value)
-  let number-width = measure([#number-text#"  "]).width
-  [#h(indent-width + number-width)#body]
+#let format-par(body, level, level-counts, indent-fn, continuation: false) = {
+  let indent-width = indent-fn(level, level-counts)
+  if continuation {
+    let current-value = level-counts.at(str(level), default: 1)
+    let number-text = numbering(get-paragraph-numbering-format(level), current-value)
+    [#h(indent-width + measure([#number-text#"  "]).width)#body]
+  } else {
+    let current-value = level-counts.at(str(level), default: 1)
+    let number-text = numbering(get-paragraph-numbering-format(level), current-value)
+    [#h(indent-width)#number-text#"  "#body]
+  }
 }
 
 // =============================================================================
@@ -302,6 +241,11 @@
 
       // Format based on element kind
       let nest_level = item.nest_level
+      let indent-fn = if memo-style == "daf" {
+        (level, _counts) => calculate-daf-indent(level)
+      } else {
+        (level, counts) => calculate-indent-from-counts(level, counts)
+      }
       let final_par = {
         if kind == "table" {
           render-memo-table(item_content)
@@ -311,42 +255,35 @@
           // level-counts still holds the value of the preceding numbered paragraph.
           if memo-style == "daf" {
             if nest_level > 0 {
-              format-daf-continuation-par(item_content, nest_level, level-counts)
+              format-par(item_content, nest_level, level-counts, indent-fn, continuation: true)
             } else {
               item_content
             }
           } else if auto-numbering {
-            format-continuation-par(item_content, nest_level, level-counts)
+            format-par(item_content, nest_level, level-counts, indent-fn, continuation: true)
           } else if nest_level > 0 {
-            format-continuation-par(item_content, nest_level - 1, level-counts)
+            format-par(item_content, nest_level - 1, level-counts, indent-fn, continuation: true)
           } else {
             item_content
           }
         } else if memo-style == "daf" {
           if nest_level > 0 {
-            let par = format-daf-par(item_content, nest_level, level-counts)
+            let par = format-par(item_content, nest_level, level-counts, indent-fn)
             level-counts.insert(str(nest_level), level-counts.at(str(nest_level), default: 1) + 1)
-            for child in range(nest_level + 1, max-levels) {
-              level-counts.insert(str(child), 1)
-            }
+            level-counts = reset-levels-from(level-counts, nest_level + 1, max-levels)
             par
           } else {
             // DAF top-level paragraphs are unnumbered and first-line indented.
             // Reset nested counters so each new top-level paragraph restarts children.
-            for child in range(max-levels) {
-              level-counts.insert(str(child), 1)
-            }
+            level-counts = reset-levels-from(level-counts, 0, max-levels)
             [#h(daf-paragraph.top-first-line-indent)#item_content]
           }
         } else if auto-numbering {
           if par_count > 1 {
             // Apply paragraph numbering per AFH 33-337 §2
-            let par = format-numbered-par(item_content, nest_level, level-counts)
-            // Advance counter for this level and reset child levels
+            let par = format-par(item_content, nest_level, level-counts, indent-fn)
             level-counts.insert(str(nest_level), level-counts.at(str(nest_level)) + 1)
-            for child in range(nest_level + 1, max-levels) {
-              level-counts.insert(str(child), 1)
-            }
+            level-counts = reset-levels-from(level-counts, nest_level + 1, max-levels)
             par
           } else {
             // AFH 33-337 §2: "A single paragraph is not numbered"
@@ -356,18 +293,14 @@
           // Unnumbered mode: only explicitly nested items (enum/list) get numbered
           if nest_level > 0 {
             let effective_level = nest_level - 1
-            let par = format-numbered-par(item_content, effective_level, level-counts)
+            let par = format-par(item_content, effective_level, level-counts, indent-fn)
             level-counts.insert(str(effective_level), level-counts.at(str(effective_level)) + 1)
-            for child in range(effective_level + 1, max-levels) {
-              level-counts.insert(str(child), 1)
-            }
+            level-counts = reset-levels-from(level-counts, effective_level + 1, max-levels)
             par
           } else {
-            // Base-level paragraphs are flush left with no numbering
-            // Reset all child level counters so subsequent list items restart at 1
-            for child in range(max-levels) {
-              level-counts.insert(str(child), 1)
-            }
+            // Base-level paragraphs are flush left with no numbering.
+            // Reset all child level counters so subsequent list items restart at 1.
+            level-counts = reset-levels-from(level-counts, 0, max-levels)
             item_content
           }
         }

--- a/src/body.typ
+++ b/src/body.typ
@@ -99,11 +99,10 @@
 // =============================================================================
 // AFH 33-337 "The Text of the Official Memorandum" §1-12 specifies:
 // - Single-space text, double-space between paragraphs
-// - Number and letter each paragraph and subparagraph
-// - "A single paragraph is not numbered" (§2)
-// - First paragraph flush left, never indented
+// - Number and letter each paragraph and subparagraph (via explicit list/enum only)
+// - Base-level paragraphs are flush left, never numbered
 // - Indent sub-paragraphs to align with first character of parent paragraph text
-#let render-body(content, auto-numbering: true) = {
+#let render-body(content) = {
   let PAR_BUFFER = state("PAR_BUFFER")
   PAR_BUFFER.update(())
   let NEST_DOWN = counter("NEST_DOWN")
@@ -212,8 +211,6 @@
   //   item.kind       — "par", "heading", "table", or "continuation"
   context {
     let heading_buffer = none
-    // Only top-level paragraphs count for AFH 33-337 §2 numbering purposes
-    let par_count = PAR_BUFFER.get().filter(item => item.kind == "par").len()
     let items = PAR_BUFFER.get()
     let total_count = items.len()
 
@@ -261,45 +258,26 @@
           // Continuation block within a multi-block list item:
           // indent to align with preceding numbered paragraph's text, no new number.
           // level-counts still holds the value of the preceding numbered paragraph.
-          if auto-numbering {
-            format-continuation-par(item_content, nest_level, level-counts)
-          } else if nest_level > 0 {
+          if nest_level > 0 {
             format-continuation-par(item_content, nest_level - 1, level-counts)
           } else {
             item_content
           }
-        } else if auto-numbering {
-          if par_count > 1 {
-            // Apply paragraph numbering per AFH 33-337 §2
-            let par = format-numbered-par(item_content, nest_level, level-counts)
-            // Advance counter for this level and reset child levels
-            level-counts.insert(str(nest_level), level-counts.at(str(nest_level)) + 1)
-            for child in range(nest_level + 1, max-levels) {
-              level-counts.insert(str(child), 1)
-            }
-            par
-          } else {
-            // AFH 33-337 §2: "A single paragraph is not numbered"
-            item_content
+        } else if nest_level > 0 {
+          let effective_level = nest_level - 1
+          let par = format-numbered-par(item_content, effective_level, level-counts)
+          level-counts.insert(str(effective_level), level-counts.at(str(effective_level)) + 1)
+          for child in range(effective_level + 1, max-levels) {
+            level-counts.insert(str(child), 1)
           }
+          par
         } else {
-          // Unnumbered mode: only explicitly nested items (enum/list) get numbered
-          if nest_level > 0 {
-            let effective_level = nest_level - 1
-            let par = format-numbered-par(item_content, effective_level, level-counts)
-            level-counts.insert(str(effective_level), level-counts.at(str(effective_level)) + 1)
-            for child in range(effective_level + 1, max-levels) {
-              level-counts.insert(str(child), 1)
-            }
-            par
-          } else {
-            // Base-level paragraphs are flush left with no numbering
-            // Reset all child level counters so subsequent list items restart at 1
-            for child in range(max-levels) {
-              level-counts.insert(str(child), 1)
-            }
-            item_content
+          // Base-level paragraphs are flush left with no numbering
+          // Reset all child level counters so subsequent list items restart at 1
+          for child in range(max-levels) {
+            level-counts.insert(str(child), 1)
           }
+          item_content
         }
       }
 

--- a/src/body.typ
+++ b/src/body.typ
@@ -99,10 +99,11 @@
 // =============================================================================
 // AFH 33-337 "The Text of the Official Memorandum" §1-12 specifies:
 // - Single-space text, double-space between paragraphs
-// - Number and letter each paragraph and subparagraph (via explicit list/enum only)
-// - Base-level paragraphs are flush left, never numbered
+// - Number and letter each paragraph and subparagraph
+// - "A single paragraph is not numbered" (§2)
+// - First paragraph flush left, never indented
 // - Indent sub-paragraphs to align with first character of parent paragraph text
-#let render-body(content) = {
+#let render-body(content, auto-numbering: true) = {
   let PAR_BUFFER = state("PAR_BUFFER")
   PAR_BUFFER.update(())
   let NEST_DOWN = counter("NEST_DOWN")
@@ -211,6 +212,8 @@
   //   item.kind       — "par", "heading", "table", or "continuation"
   context {
     let heading_buffer = none
+    // Only top-level paragraphs count for AFH 33-337 §2 numbering purposes
+    let par_count = PAR_BUFFER.get().filter(item => item.kind == "par").len()
     let items = PAR_BUFFER.get()
     let total_count = items.len()
 
@@ -258,26 +261,45 @@
           // Continuation block within a multi-block list item:
           // indent to align with preceding numbered paragraph's text, no new number.
           // level-counts still holds the value of the preceding numbered paragraph.
-          if nest_level > 0 {
+          if auto-numbering {
+            format-continuation-par(item_content, nest_level, level-counts)
+          } else if nest_level > 0 {
             format-continuation-par(item_content, nest_level - 1, level-counts)
           } else {
             item_content
           }
-        } else if nest_level > 0 {
-          let effective_level = nest_level - 1
-          let par = format-numbered-par(item_content, effective_level, level-counts)
-          level-counts.insert(str(effective_level), level-counts.at(str(effective_level)) + 1)
-          for child in range(effective_level + 1, max-levels) {
-            level-counts.insert(str(child), 1)
+        } else if auto-numbering {
+          if par_count > 1 {
+            // Apply paragraph numbering per AFH 33-337 §2
+            let par = format-numbered-par(item_content, nest_level, level-counts)
+            // Advance counter for this level and reset child levels
+            level-counts.insert(str(nest_level), level-counts.at(str(nest_level)) + 1)
+            for child in range(nest_level + 1, max-levels) {
+              level-counts.insert(str(child), 1)
+            }
+            par
+          } else {
+            // AFH 33-337 §2: "A single paragraph is not numbered"
+            item_content
           }
-          par
         } else {
-          // Base-level paragraphs are flush left with no numbering
-          // Reset all child level counters so subsequent list items restart at 1
-          for child in range(max-levels) {
-            level-counts.insert(str(child), 1)
+          // Unnumbered mode: only explicitly nested items (enum/list) get numbered
+          if nest_level > 0 {
+            let effective_level = nest_level - 1
+            let par = format-numbered-par(item_content, effective_level, level-counts)
+            level-counts.insert(str(effective_level), level-counts.at(str(effective_level)) + 1)
+            for child in range(effective_level + 1, max-levels) {
+              level-counts.insert(str(child), 1)
+            }
+            par
+          } else {
+            // Base-level paragraphs are flush left with no numbering
+            // Reset all child level counters so subsequent list items restart at 1
+            for child in range(max-levels) {
+              level-counts.insert(str(child), 1)
+            }
+            item_content
           }
-          item_content
         }
       }
 

--- a/src/body.typ
+++ b/src/body.typ
@@ -94,6 +94,56 @@
   [#h(indent-width + number-width)#body]
 }
 
+/// Calculates fixed indentation for DAF paragraph levels.
+///
+/// DAF style uses fixed 0.5in indentation steps per nesting level.
+/// - Level 1: 0.5in
+/// - Level 2: 1.0in
+/// - Level N: N * 0.5in
+///
+/// - level (int): Paragraph nesting level (0-based)
+/// -> length
+#let calculate-daf-indent(level) = {
+  if level <= 0 {
+    return 0pt
+  }
+  level * 0.5in
+}
+
+/// Formats a DAF nested paragraph with fixed indentation and numbering.
+///
+/// DAF nested items begin at level 1 ("a.") and indent by fixed 0.5in per level.
+///
+/// - body (content): Paragraph content to format
+/// - level (int): Paragraph nesting level (0-based)
+/// - level-counts (dictionary): Current counter values per level
+/// -> content
+#let format-daf-par(body, level, level-counts) = {
+  let current-value = level-counts.at(str(level), default: 1)
+  let format = get-paragraph-numbering-format(level)
+  let number-text = numbering(format, current-value)
+  let indent-width = calculate-daf-indent(level)
+  [#h(indent-width)#number-text#"  "#body]
+}
+
+/// Formats a DAF continuation paragraph with fixed indentation.
+///
+/// Continuation lines align with the first text character after the numbered
+/// label for the current nested level.
+///
+/// - body (content): Continuation paragraph content to format
+/// - level (int): Paragraph nesting level (0-based)
+/// - level-counts (dictionary): Current counter values per level
+/// -> content
+#let format-daf-continuation-par(body, level, level-counts) = {
+  let indent-width = calculate-daf-indent(level)
+  let current-value = level-counts.at(str(level), default: 1)
+  let format = get-paragraph-numbering-format(level)
+  let number-text = numbering(format, current-value)
+  let number-width = measure([#number-text#"  "]).width
+  [#h(indent-width + number-width)#body]
+}
+
 // =============================================================================
 // PARAGRAPH BODY RENDERING
 // =============================================================================
@@ -103,7 +153,7 @@
 // - "A single paragraph is not numbered" (§2)
 // - First paragraph flush left, never indented
 // - Indent sub-paragraphs to align with first character of parent paragraph text
-#let render-body(content, auto-numbering: true) = {
+#let render-body(content, auto-numbering: true, memo-style: "usaf") = {
   let PAR_BUFFER = state("PAR_BUFFER")
   PAR_BUFFER.update(())
   let NEST_DOWN = counter("NEST_DOWN")
@@ -261,12 +311,34 @@
           // Continuation block within a multi-block list item:
           // indent to align with preceding numbered paragraph's text, no new number.
           // level-counts still holds the value of the preceding numbered paragraph.
-          if auto-numbering {
+          if memo-style == "daf" {
+            if nest_level > 0 {
+              format-daf-continuation-par(item_content, nest_level, level-counts)
+            } else {
+              item_content
+            }
+          } else if auto-numbering {
             format-continuation-par(item_content, nest_level, level-counts)
           } else if nest_level > 0 {
             format-continuation-par(item_content, nest_level - 1, level-counts)
           } else {
             item_content
+          }
+        } else if memo-style == "daf" {
+          if nest_level > 0 {
+            let par = format-daf-par(item_content, nest_level, level-counts)
+            level-counts.insert(str(nest_level), level-counts.at(str(nest_level), default: 1) + 1)
+            for child in range(nest_level + 1, max-levels) {
+              level-counts.insert(str(child), 1)
+            }
+            par
+          } else {
+            // DAF top-level paragraphs are unnumbered and first-line indented.
+            // Reset nested counters so each new top-level paragraph restarts children.
+            for child in range(max-levels) {
+              level-counts.insert(str(child), 1)
+            }
+            [#h(0.5in)#item_content]
           }
         } else if auto-numbering {
           if par_count > 1 {

--- a/src/config.typ
+++ b/src/config.typ
@@ -21,8 +21,8 @@
 // =============================================================================
 // AFH 33-337 §5: "Use 12 point Times New Roman font for text"
 
-#let DEFAULT_LETTERHEAD_FONTS = ("Copperplate CC",)
-#let DEFAULT_BODY_FONTS = ("times new roman", "NimbusRomNo9L")  // AFH 33-337 §5: Times New Roman required
+#let DEFAULT_LETTERHEAD_FONTS = ("NimbusRomNo9L", "times new roman")
+#let DEFAULT_BODY_FONTS = ("NimbusRomNo9L", "times new roman")  // AFH 33-337 §5: Times New Roman required
 #let LETTERHEAD_COLOR = rgb("#204093")  // Faded USAF blue for letterhead
 
 // =============================================================================

--- a/src/config.typ
+++ b/src/config.typ
@@ -66,7 +66,6 @@
 
 #let CLASSIFICATION_COLORS = (
   "UNCLASSIFIED": rgb(0, 122, 51), // Forest green (#007A33)
-  "CONFIDENTIAL": rgb(0, 51, 160), // Deep blue (#0033A0)
   "SECRET": rgb(200, 16, 46), // Crimson red (#C8102E)
   "TOP SECRET": rgb(255, 103, 31), // Burnt orange (#FF671F)
 )

--- a/src/config.typ
+++ b/src/config.typ
@@ -39,6 +39,14 @@
   numbering-formats: ("1.", "a.", "(1)", "(a)", n => underline(str(n)), n => underline(str(n))),
 )
 
+// DAF (Headquarters) memo body: first-line indent for unnumbered paragraphs; nested
+// items start at 1in, then +0.5in per additional nesting depth.
+#let daf-paragraph = (
+  top-first-line-indent: 0.5in,
+  nested-first-level-indent: 1in,
+  nested-step: 0.5in,
+)
+
 // =============================================================================
 // COUNTERS
 // =============================================================================

--- a/src/frontmatter.typ
+++ b/src/frontmatter.typ
@@ -25,11 +25,16 @@
   classification_level: none,
   footer_tag_line: none,
   auto_numbering: true,
+  memo_style: "usaf",
   it,
 ) = {
   assert(subject != none, message: "subject is required")
   assert(memo_for != none, message: "memo_for is required")
   assert(memo_from != none, message: "memo_from is required")
+  assert(
+    memo_style in ("usaf", "daf"),
+    message: "memo_style must be \"usaf\" or \"daf\"",
+  )
 
   let actual_date = if date == none { datetime.today() } else { date }
   let classification_color = get-classification-level-color(classification_level)
@@ -108,6 +113,7 @@
     body_font: body_font,
     font_size: font_size,
     auto_numbering: auto_numbering,
+    memo_style: memo_style,
   ))
 
   it

--- a/src/frontmatter.typ
+++ b/src/frontmatter.typ
@@ -24,6 +24,7 @@
   memo_for_cols: 3,
   classification_level: none,
   footer_tag_line: none,
+  auto_numbering: true,
   it,
 ) = {
   assert(subject != none, message: "subject is required")
@@ -106,6 +107,7 @@
     original_from: first-or-value(memo_from),
     body_font: body_font,
     font_size: font_size,
+    auto_numbering: auto_numbering,
   ))
 
   it

--- a/src/frontmatter.typ
+++ b/src/frontmatter.typ
@@ -24,7 +24,6 @@
   memo_for_cols: 3,
   classification_level: none,
   footer_tag_line: none,
-  auto_numbering: true,
   it,
 ) = {
   assert(subject != none, message: "subject is required")
@@ -107,7 +106,6 @@
     original_from: first-or-value(memo_from),
     body_font: body_font,
     font_size: font_size,
-    auto_numbering: auto_numbering,
   ))
 
   it

--- a/src/frontmatter.typ
+++ b/src/frontmatter.typ
@@ -18,6 +18,7 @@
   letterhead_title: "DEPARTMENT OF THE AIR FORCE",
   letterhead_caption: "[YOUR SQUADRON/UNIT NAME]",
   letterhead_seal: none,
+  letterhead_seal_subtitle: none, // optional line under seal (9pt bold caps); ignored if no seal
   letterhead_font: DEFAULT_LETTERHEAD_FONTS,
   body_font: DEFAULT_BODY_FONTS,
   font_size: 12pt,
@@ -94,7 +95,13 @@
     },
   )
 
-  render-letterhead(letterhead_title, letterhead_caption, letterhead_seal, letterhead_font)
+  render-letterhead(
+    letterhead_title,
+    letterhead_caption,
+    letterhead_font,
+    letterhead-seal: letterhead_seal,
+    letterhead-seal-subtitle: letterhead_seal_subtitle,
+  )
 
   // AFH 33-337 "Date": "Place the date 1 inch from the right edge, 1.75 inches from the top"
   // Since we have a 1-inch top margin, we need (1.75in - margin) vertical space

--- a/src/frontmatter.typ
+++ b/src/frontmatter.typ
@@ -100,7 +100,7 @@
   // Since we have a 1-inch top margin, we need (1.75in - margin) vertical space
   v(1.75in - spacing.margin)
 
-  render-date-section(actual_date)
+  render-date-section(actual_date, memo-style: memo_style)
   render-for-section(memo_for, memo_for_cols)
   render-from-section(memo_from)
   render-subject-section(subject)

--- a/src/indorsement.typ
+++ b/src/indorsement.typ
@@ -59,6 +59,7 @@
 
     context {
       let config = query(metadata).last().value
+      let memo-style = config.at("memo_style", default: "usaf")
       let original_subject = config.subject
       let original_date = config.original_date
       let original_from = config.original_from
@@ -69,12 +70,12 @@
 
       if format == "separate_page" {
         pagebreak()
-        [#indorsement_label to #original_from, #display-date(original_date), #original_subject]
+        [#indorsement_label to #original_from, #display-date(original_date, memo-style: memo-style), #original_subject]
 
         blank-line()
         grid(
           columns: (auto, 1fr),
-          ind_from, align(right)[#display-date(actual_date)],
+          ind_from, align(right)[#display-date(actual_date, memo-style: memo-style)],
         )
 
         blank-line()
@@ -86,7 +87,7 @@
         blank-line()
         grid(
           columns: (auto, 1fr),
-          [#indorsement_label, #ind_from], align(right)[#display-date(actual_date)],
+          [#indorsement_label, #ind_from], align(right)[#display-date(actual_date, memo-style: memo-style)],
         )
 
         blank-line()

--- a/src/indorsement.typ
+++ b/src/indorsement.typ
@@ -44,14 +44,6 @@
   let actual_date = if date == none { datetime.today() } else { date }
   let ind_from = first-or-value(from)
   let ind_for = to
-  let memo-style = context {
-    let metadata-items = query(metadata)
-    if metadata-items.len() > 0 {
-      metadata-items.last().value.at("memo_style", default: "usaf")
-    } else {
-      "usaf"
-    }
-  }
 
   if format != "informal" {
     // Step the counter BEFORE the context block to avoid read-then-update loop
@@ -105,23 +97,15 @@
     render-action-line(action)
   }
 
-  render-body(content, memo-style: memo-style)
+  context {
+    let memo-style = {
+      let items = query(metadata)
+      if items.len() > 0 { items.last().value.at("memo_style", default: "usaf") } else { "usaf" }
+    }
+    render-body(content, memo-style: memo-style)
+  }
 
   render-signature-block(signature_block, signature-blank-lines: signature_blank_lines)
 
-  if not falsey(attachments) {
-    calculate-backmatter-spacing(true)
-    let attachment-count = attachments.len()
-    let section-label = if attachment-count == 1 { "Attachment:" } else { str(attachment-count) + " Attachments:" }
-    let continuation-label = (
-      (if attachment-count == 1 { "Attachment" } else { str(attachment-count) + " Attachments" })
-        + " (listed on next page):"
-    )
-    render-backmatter-section(attachments, section-label, numbering-style: "1.", continuation-label: continuation-label)
-  }
-
-  if not falsey(cc) {
-    calculate-backmatter-spacing(falsey(attachments))
-    render-backmatter-section(cc, "cc:")
-  }
+  render-backmatter-sections(attachments: attachments, cc: cc)
 }

--- a/src/indorsement.typ
+++ b/src/indorsement.typ
@@ -44,6 +44,14 @@
   let actual_date = if date == none { datetime.today() } else { date }
   let ind_from = first-or-value(from)
   let ind_for = to
+  let memo-style = context {
+    let metadata-items = query(metadata)
+    if metadata-items.len() > 0 {
+      metadata-items.last().value.at("memo_style", default: "usaf")
+    } else {
+      "usaf"
+    }
+  }
 
   if format != "informal" {
     // Step the counter BEFORE the context block to avoid read-then-update loop
@@ -96,7 +104,7 @@
     render-action-line(action)
   }
 
-  render-body(content)
+  render-body(content, memo-style: memo-style)
 
   render-signature-block(signature_block, signature-blank-lines: signature_blank_lines)
 

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -28,12 +28,14 @@
 //   subject: "Your Subject Here",
 //   memo_for: ("OFFICE/SYMBOL",),
 //   memo_from: ("YOUR/SYMBOL",),
+//   memo_style: "usaf", // "usaf" (default) or "daf"
 // )
 //
 // #show: mainmatter
 //
 // Your memo body content here.
-// (Paragraphs are automatically numbered per AFH 33-337)
+// (USAF style auto-numbers per AFH 33-337; DAF style uses unnumbered
+// top-level paragraphs with fixed 0.5in first-line indentation)
 //
 // #backmatter(
 //   signature_block: ("NAME, Rank, USAF", "Title"),

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -33,7 +33,7 @@
 // #show: mainmatter
 //
 // Your memo body content here.
-// (Use list/enum for AFH-style subparagraph numbering; base paragraphs stay unnumbered.)
+// (Paragraphs are automatically numbered per AFH 33-337)
 //
 // #backmatter(
 //   signature_block: ("NAME, Rank, USAF", "Title"),

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -33,7 +33,7 @@
 // #show: mainmatter
 //
 // Your memo body content here.
-// (Paragraphs are automatically numbered per AFH 33-337)
+// (Use list/enum for AFH-style subparagraph numbering; base paragraphs stay unnumbered.)
 //
 // #backmatter(
 //   signature_block: ("NAME, Rank, USAF", "Title"),

--- a/src/mainmatter.typ
+++ b/src/mainmatter.typ
@@ -10,9 +10,22 @@
 /// AFH 33-337 "The Text of the Official Memorandum" §1-12 requirements:
 /// - Begin text on second line below subject/references
 /// - Single-space text, double-space between paragraphs
-/// - Base-level paragraphs are flush left and unnumbered
-/// - Explicit list/enum items receive hierarchical AFH-style numbering
+/// - Number and letter each paragraph/subparagraph
+/// - "A single paragraph is not numbered" (§2)
+/// - First paragraph flush left, never indented
+///
+/// Applies AFH 33-337 paragraph numbering and formatting to the main body
+/// of the memorandum. Automatically detects single vs. multiple paragraphs
+/// to comply with AFH 33-337 numbering requirements.
+///
+/// When `auto_numbering` is false (set in frontmatter), base-level paragraphs
+/// render flush left without numbering. Only explicitly numbered or bulleted
+/// items enter the numbering hierarchy.
 ///
 /// - content (content): The body content to render
 /// -> content
-#let mainmatter(it) = render-body(it)
+#let mainmatter(it) = context {
+  let config = query(metadata).last().value
+  let auto-numbering = config.at("auto_numbering", default: true)
+  render-body(it, auto-numbering: auto-numbering)
+}

--- a/src/mainmatter.typ
+++ b/src/mainmatter.typ
@@ -3,7 +3,6 @@
 // This module implements the mainmatter (body text) of a USAF memorandum per
 // AFH 33-337 Chapter 14 "The Text of the Official Memorandum" (§1-12).
 
-#import "primitives.typ": *
 #import "body.typ": *
 
 /// Mainmatter show rule for USAF memorandum body content.
@@ -11,22 +10,9 @@
 /// AFH 33-337 "The Text of the Official Memorandum" §1-12 requirements:
 /// - Begin text on second line below subject/references
 /// - Single-space text, double-space between paragraphs
-/// - Number and letter each paragraph/subparagraph
-/// - "A single paragraph is not numbered" (§2)
-/// - First paragraph flush left, never indented
-///
-/// Applies AFH 33-337 paragraph numbering and formatting to the main body
-/// of the memorandum. Automatically detects single vs. multiple paragraphs
-/// to comply with AFH 33-337 numbering requirements.
-///
-/// When auto_numbering is false (set in frontmatter), base-level paragraphs
-/// render flush left without numbering. Only explicitly numbered or bulleted
-/// items enter the numbering hierarchy.
+/// - Base-level paragraphs are flush left and unnumbered
+/// - Explicit list/enum items receive hierarchical AFH-style numbering
 ///
 /// - content (content): The body content to render
 /// -> content
-#let mainmatter(it) = context {
-  let config = query(metadata).last().value
-  let auto-numbering = config.at("auto_numbering", default: true)
-  render-body(it, auto-numbering: auto-numbering)
-}
+#let mainmatter(it) = render-body(it)

--- a/src/mainmatter.typ
+++ b/src/mainmatter.typ
@@ -27,5 +27,6 @@
 #let mainmatter(it) = context {
   let config = query(metadata).last().value
   let auto-numbering = config.at("auto_numbering", default: true)
-  render-body(it, auto-numbering: auto-numbering)
+  let memo-style = config.at("memo_style", default: "usaf")
+  render-body(it, auto-numbering: auto-numbering, memo-style: memo-style)
 }

--- a/src/primitives.typ
+++ b/src/primitives.typ
@@ -130,7 +130,7 @@
     blank-line()
     grid(
       columns: (auto, auto, 1fr),
-      "References:", "  ", enum(..references, numbering: "(a)"),
+      "References:", "  ", enum(..references, numbering: "(a) ", body-indent: 0pt),
     )
   }
 }

--- a/src/primitives.typ
+++ b/src/primitives.typ
@@ -16,7 +16,10 @@
 
 #let render-letterhead(title, caption, letterhead-seal, font) = {
   font = ensure-array(font)
+  title = ensure-string(title)
   caption = ensure-string(caption)
+  title = upper(title)
+  caption = upper(caption)
 
   place(
     dy: 0.625in - spacing.margin,
@@ -28,7 +31,7 @@
         #place(
           center + top,
           align(center)[
-            #set text(12pt, font: font, fill: LETTERHEAD_COLOR)
+            #set text(12pt, font: font, fill: LETTERHEAD_COLOR, weight: "bold")
             #title\
             #text(10.5pt)[#caption]
           ],

--- a/src/primitives.typ
+++ b/src/primitives.typ
@@ -59,8 +59,8 @@
 // - SUBJECT: Second line below FROM
 
 // AFH 33-337 "Date": "Place the date 1 inch from the right edge, 1.75 inches from the top"
-#let render-date-section(date) = {
-  align(right)[#display-date(date)]
+#let render-date-section(date, memo-style: "usaf") = {
+  align(right)[#display-date(date, memo-style: memo-style)]
 }
 
 // AFH 33-337 "MEMORANDUM FOR": "Place 'MEMORANDUM FOR' on the second line below the date"

--- a/src/primitives.typ
+++ b/src/primitives.typ
@@ -234,10 +234,12 @@
   context {
     let available-space = page.height - here().position().y - 1in
     if measure(formatted-content).height > available-space {
+      // Attachments pass continuation-label ("… (listed on next page):" per AFH 33-337).
+      // cc: and DISTRIBUTION: use a neutral default — "listed" applies to attachment lists only.
       let continuation-text = if continuation-label != none {
         text()[#continuation-label]
       } else {
-        text()[#section-label + " (listed on next page):"]
+        text()[#(section-label + " (continued on next page)")]
       }
       continuation-text
       pagebreak()

--- a/src/primitives.typ
+++ b/src/primitives.typ
@@ -14,7 +14,13 @@
 // Letterhead placement is not explicitly specified in AFH 33-337, but follows
 // standard USAF memo formatting conventions
 
-#let render-letterhead(title, caption, letterhead-seal, font) = {
+#let render-letterhead(
+  title,
+  caption,
+  font,
+  letterhead-seal: none,
+  letterhead-seal-subtitle: none,
+) = {
   font = ensure-array(font)
   title = ensure-string(title)
   caption = ensure-string(caption)
@@ -41,20 +47,27 @@
   )
 
   if letterhead-seal != none {
-    place(
-      left + top,
-      dx: -0.5in,
-      dy: -.5in,
+    let seal-body = if falsey(letterhead-seal-subtitle) {
+      block[
+        #fit-box(width: 2in, height: 1in)[#letterhead-seal]
+      ]
+    } else {
       block(width: 2in)[
         #align(left)[
           #stack(spacing: 0.15em)[
             #fit-box(width: 2in, height: 1in)[#letterhead-seal]
             #text(9pt, font: font, fill: LETTERHEAD_COLOR, weight: "bold")[
-              OFFICE OF THE SECRETARY
+              #upper(ensure-string(letterhead-seal-subtitle))
             ]
           ]
         ]
-      ],
+      ]
+    }
+    place(
+      left + top,
+      dx: -0.5in,
+      dy: -.5in,
+      seal-body,
     )
   }
 }

--- a/src/primitives.typ
+++ b/src/primitives.typ
@@ -45,8 +45,15 @@
       left + top,
       dx: -0.5in,
       dy: -.5in,
-      block[
-        #fit-box(width: 2in, height: 1in)[#letterhead-seal]
+      block(width: 2in)[
+        #align(left)[
+          #stack(spacing: 0.15em)[
+            #fit-box(width: 2in, height: 1in)[#letterhead-seal]
+            #text(9pt, font: font, fill: LETTERHEAD_COLOR, weight: "bold")[
+              OFFICE OF THE SECRETARY
+            ]
+          ]
+        ]
       ],
     )
   }

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -79,65 +79,28 @@
   ]
 }
 
-/// Checks if a string is in ISO date format (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS).
+/// Formats a date for the memo heading.
 ///
-/// Performs a simple pattern check for ISO 8601 date strings by verifying:
-/// - String is at least 10 characters long
-/// - Characters at positions 4 and 7 are dashes
-///
-/// - date-str (str): String to check for ISO date pattern
-/// -> bool
-#let is-iso-date-string(date-str) = {
-  if date-str.len() == 10 {
-    let char4 = date-str.at(4)
-    let char7 = date-str.at(7)
-    return char4 == "-" and char7 == "-"
-  } else if date-str.len() > 10 {
-    let char4 = date-str.at(4)
-    let char7 = date-str.at(7)
-    let char10 = date-str.at(10)
-    return char4 == "-" and char7 == "-" and char10 == "T"
-  }
-  return false
-}
-
-/// Extracts the date portion (YYYY-MM-DD) from an ISO date string.
-///
-/// Returns the first 10 characters which contain the date portion of an
-/// ISO 8601 date string, removing any time component if present.
-///
-/// - date-str (str): ISO date string to extract from
-/// -> str
-#let extract-iso-date(date-str) = {
-  date-str.slice(0, 10)
-}
-
-/// Formats a date in standard military format or ISO format depending on input type.
-///
-/// AFH 33-337 "Date": "Use the 'Day Month Year' or 'DD Mmm YY' format for documents
-/// addressed to a military organization. For civilian addressees, use the 'Month Day, Year' format."
-/// Examples: "15 October 2014" or "15 Oct 14" for military, "October 15, 2014" for civilian
-///
-/// Intelligently handles different date input formats:
-/// - ISO string (YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS): Parsed via TOML and displayed in military format
-/// - Non-ISO string: Displayed as-is
-/// - datetime object: Displayed in military format ("1 January 2024")
+/// - String: shown as-is (use for fixed text like placeholders).
+/// - datetime: USAF style `DD Month YYYY`; DAF style `Month DD, YYYY`.
 ///
 /// - date (str|datetime): Date to format for display
-/// -> str
-#let display-date(date) = {
+/// - memo-style (str): `"usaf"` or `"daf"`
+/// -> content
+#let display-date(date, memo-style: "usaf") = {
+  assert(
+    memo-style in ("usaf", "daf"),
+    message: "memo-style for display-date must be \"usaf\" or \"daf\"",
+  )
   if type(date) == str {
-    if is-iso-date-string(date) {
-      // Parse ISO date string using TOML to get datetime object
-      let iso-date = extract-iso-date(date)
-      let toml-str = "date = " + iso-date
-      let parsed = toml(bytes(toml-str))
-      parsed.date.display("[day padding:none] [month repr:long] [year]")
-    } else {
-      date
-    }
+    date
   } else {
-    date.display("[day padding:none] [month repr:long] [year]")
+    let pattern = if memo-style == "daf" {
+      "[month repr:long] [day padding:none], [year]"
+    } else {
+      "[day padding:none] [month repr:long] [year]"
+    }
+    date.display(pattern)
   }
 }
 

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -104,24 +104,26 @@
   }
 }
 
-/// Gets the color associated with a classification level.
+/// Gets the banner color for a classification marking.
 ///
-/// - level (str): Classification level string
+/// Matches when `level` (trimmed) starts with a known prefix: TOP SECRET, SECRET, or UNCLASSIFIED.
+/// Otherwise returns black.
+///
+/// - level (str): Marking string shown in header/footer
 /// -> color
 #let get-classification-level-color(level) = {
-  if level == none {
-    return rgb(0, 0, 0) // Default to black if no classification
+  if level == none or type(level) != str {
+    return rgb(0, 0, 0)
   }
-  // Order matters - check most specific first
-  let level-order = ("TOP SECRET", "SECRET", "CONFIDENTIAL", "UNCLASSIFIED")
-
+  let s = level.trim()
+  // "TOP SECRET" before "SECRET" so the full phrase matches first.
+  let level-order = ("TOP SECRET", "SECRET", "UNCLASSIFIED")
   for base-level in level-order {
-    if base-level in level {
+    if s.starts-with(base-level) {
       return CLASSIFICATION_COLORS.at(base-level)
     }
   }
-
-  rgb(0, 0, 0) // Default
+  rgb(0, 0, 0)
 }
 
 // =============================================================================

--- a/template/README.md
+++ b/template/README.md
@@ -1,3 +1,1 @@
-If you are using the Typst web app, download the letterhead font and upload it to your project folder:
-
-[CopperplateCC-Heavy.otf](https://github.com/nibsbin/tonguetoquill-usaf-memo/raw/main/fonts/CopperplateCC/CopperplateCC-Heavy.otf)
+If you are using the Typst web app, download the [NimbusRomNo9L](https://github.com/nibsbin/tonguetoquill-usaf-memo/tree/main/fonts/NimbusRomanNo9L) font files and upload them to your project folder so letterhead and body text match Times New Roman. Optionally add [Cinzel](https://github.com/nibsbin/tonguetoquill-usaf-memo/tree/main/fonts/Cinzel) if you use a footer tagline.

--- a/template/daf-template.typ
+++ b/template/daf-template.typ
@@ -3,7 +3,7 @@
 
 #show: frontmatter.with(
   letterhead_title: "DEPARTMENT OF THE AIR FORCE",
-  letterhead_caption: "OFFICE OF THE CHIEF INFORMATION OFFICER",
+  letterhead_caption: "washington, DC",
   letterhead_seal: image("assets/dow_seal.png"),
   date: datetime(month:1,day:1,year:2024),
   subject: "Format for the Official Memorandum",

--- a/template/daf-template.typ
+++ b/template/daf-template.typ
@@ -3,35 +3,37 @@
 
 #show: frontmatter.with(
   letterhead_title: "DEPARTMENT OF THE AIR FORCE",
-  letterhead_caption: "123RD OPERATIONS SQUADRON",
+  letterhead_caption: "OFFICE OF THE CHIEF INFORMATION OFFICER",
   letterhead_seal: image("assets/dow_seal.png"),
-  subject: "DAF Memorandum Paragraph Style Example",
-  memo_for: "123 OG/CC",
+  date: "Month DD, Year",
+  subject: "Format for the Official Memorandum",
+  memo_for: "XXXX",
   memo_from: (
-    "123 OS/CC",
-    "123rd Operations Squadron",
-    "Any Base AFB ST 12345",
+    "SAF/CN",
+    "1800 Air Force Pentagon",
+    "Washington, D.C., 20330-1665",
   ),
+  references: ("HOI 33-3, Correspondence Preparation, Control, and Tracking",),
   memo_style: "daf",
 )
 
 #mainmatter[
-  This top-level paragraph demonstrates DAF memo style behavior. It is not automatically numbered, and the first line is indented by one-half inch from the left margin.
+  As an action officer, you will prepare official memorandums for the signature of your senior leader using the Headquarters of the Department of the Air Force official memorandum format. This format is unique to the executive part of the Department of the Air Force and differs from other types of correspondence described in the Tongue and Quill.
 
-  This second top-level paragraph is also unnumbered with the same first-line indentation. Nested content below starts at the alpha level.
+  Type paragraphs in an indented style 0.5" from the left margin, single-spaced, with double spaces between them. Keep brief, preferably no longer than one page.
 
-  + First nested paragraph at DAF level 2 style. It renders with an alpha marker (`a.`, `b.`, `c.`) and an additional half-inch nested indent.
+  + A subdivided paragraph must have at least two subdivisions.
 
-  + Second nested paragraph at the same level. This body intentionally wraps onto additional lines to show alignment behavior after the numbered marker at this nesting depth.
+  + If there is a subparagraph "a," there must be a subparagraph "b." Indent the subparagraph an additional 0.5 inch.
 
-    + Deeper nested paragraph example. This level increases indentation by another half inch and advances to the next numbering format.
-
-    + Another deep nested paragraph at the same depth to demonstrate progression and spacing consistency.
+  If appropriate, include a statement of reference to email and telephone concerning the subject matter.
 ]
 
 #backmatter(
   signature_block: (
-    "JANE Q. EXAMPLE, Lt Col, USAF",
-    "Commander",
+    "VENICE M. GOODWINE, SES, DAF",
+    "Chief Information Officer",
   ),
+  attachments: ("Listed here",),
+  cc: ("ORG/SYM",),
 )

--- a/template/daf-template.typ
+++ b/template/daf-template.typ
@@ -5,6 +5,7 @@
   letterhead_title: "DEPARTMENT OF THE AIR FORCE",
   letterhead_caption: "washington, DC",
   letterhead_seal: image("assets/dow_seal.png"),
+  letterhead_seal_subtitle: "Office of the Secretary",
   date: datetime(month:1,day:1,year:2024),
   subject: "Format for the Official Memorandum",
   memo_for: "XXXX",

--- a/template/daf-template.typ
+++ b/template/daf-template.typ
@@ -1,0 +1,36 @@
+#import "@preview/tonguetoquill-usaf-memo:2.0.0": backmatter, frontmatter, mainmatter
+
+#show: frontmatter.with(
+  letterhead_title: "DEPARTMENT OF THE AIR FORCE",
+  letterhead_caption: "123RD OPERATIONS SQUADRON",
+  letterhead_seal: image("assets/dow_seal.png"),
+  subject: "DAF Memorandum Paragraph Style Example",
+  memo_for: "123 OG/CC",
+  memo_from: (
+    "123 OS/CC",
+    "123rd Operations Squadron",
+    "Any Base AFB ST 12345",
+  ),
+  memo_style: "daf",
+)
+
+#mainmatter[
+  This top-level paragraph demonstrates DAF memo style behavior. It is not automatically numbered, and the first line is indented by one-half inch from the left margin.
+
+  This second top-level paragraph is also unnumbered with the same first-line indentation. Nested content below starts at the alpha level.
+
+  + First nested paragraph at DAF level 2 style. It renders with an alpha marker (`a.`, `b.`, `c.`) and an additional half-inch nested indent.
+
+  + Second nested paragraph at the same level. This body intentionally wraps onto additional lines to show alignment behavior after the numbered marker at this nesting depth.
+
+    + Deeper nested paragraph example. This level increases indentation by another half inch and advances to the next numbering format.
+
+    + Another deep nested paragraph at the same depth to demonstrate progression and spacing consistency.
+]
+
+#backmatter(
+  signature_block: (
+    "JANE Q. EXAMPLE, Lt Col, USAF",
+    "Commander",
+  ),
+)

--- a/template/daf-template.typ
+++ b/template/daf-template.typ
@@ -5,7 +5,7 @@
   letterhead_title: "DEPARTMENT OF THE AIR FORCE",
   letterhead_caption: "OFFICE OF THE CHIEF INFORMATION OFFICER",
   letterhead_seal: image("assets/dow_seal.png"),
-  date: "Month DD, Year",
+  date: datetime(month:1,day:1,year:2024),
   subject: "Format for the Official Memorandum",
   memo_for: "XXXX",
   memo_from: (

--- a/template/daf-template.typ
+++ b/template/daf-template.typ
@@ -1,4 +1,5 @@
-#import "@preview/tonguetoquill-usaf-memo:2.0.0": backmatter, frontmatter, mainmatter
+// Local import: `memo_style` is not yet in the published package; swap to @preview after release.
+#import "/src/lib.typ": backmatter, frontmatter, mainmatter
 
 #show: frontmatter.with(
   letterhead_title: "DEPARTMENT OF THE AIR FORCE",

--- a/template/usaf-template.typ
+++ b/template/usaf-template.typ
@@ -114,7 +114,7 @@
     "Duty Title",
   ),
   format: "separate_page",
-  date: "2001-01-01",
+  date: datetime(year: 2001, month: 1, day: 1),
 )[
   Use a new page indorsement when there isn't space remaining on the original memorandum or previous indorsement page. The new-page indorsement is basically the same as the one for the same page, except the top line always cites the indorsement number with the originator's office, date, and subject of the original communication; the second line reflects the functional address symbol of the indorsing office with the date.
 ]

--- a/template/usaf-template.typ
+++ b/template/usaf-template.typ
@@ -30,7 +30,7 @@
 
   - #strong[If you are on the Typst app, upload #text(color.blue)[#link("https://github.com/nibsbin/tonguetoquill-usaf-memo/raw/main/fonts/CopperplateCC/CopperplateCC-Heavy.otf")[Copperplate CC]] to your project folder]
 
-  Note that this template provides proper formatting for various elements via Typst functions. The recipient line uses proper grid formatting, the body uses automatic paragraph numbering, the signature block uses precise positioning, and so on. The template handles all AFH 33-337 formatting requirements automatically.
+  Note that this template provides proper formatting for various elements via Typst functions. The recipient line uses proper grid formatting, the body uses list/enum for hierarchical subparagraph numbering, the signature block uses precise positioning, and so on. The template handles all AFH 33-337 formatting requirements automatically.
 
   Place "MEMORANDUM FOR" on the second line below the date. Leave two spaces between "MEMORANDUM FOR" and the recipient's office symbol. If there are multiple recipients, two or three office symbols may be placed on each line aligned under the entries on the first line. If there are numerous recipients, type "DISTRIBUTION" after "MEMORANDUM FOR" and use a "DISTRIBUTION" element below the signature block.
 

--- a/template/usaf-template.typ
+++ b/template/usaf-template.typ
@@ -26,9 +26,9 @@
 )
 
 #mainmatter[
-  Use only *approved organizational letterhead* for all correspondence. This applies to all letterhead, both pre-printed and computer generated. Reference (a) details the format and style of official letterhead such as centering the first line of the header 5/8ths of an inch from the top of the page in 12 point Copperplate Gothic Bold font. The second header line is centered 3 points below the first line in 10.5 point Copperplate Gothic Bold font.
+  Use approved organizational letterhead for all correspondence. This applies to all letterhead, both pre-printed and computer generated. Reference (a) describes placement of the official header lines; this template centers the first line 5/8 inch from the top in 12 point bold Times New Roman (or *NimbusRomNo9L*), with the second line 3 points below in 10.5 point.
 
-  - #strong[If you are on the Typst app, upload #text(color.blue)[#link("https://github.com/nibsbin/tonguetoquill-usaf-memo/raw/main/fonts/CopperplateCC/CopperplateCC-Heavy.otf")[Copperplate CC]] to your project folder]
+  - #strong[If you are on the Typst app, upload the #text(color.blue)[#link("https://github.com/nibsbin/tonguetoquill-usaf-memo/tree/main/fonts/NimbusRomanNo9L")[NimbusRomNo9L]] font files (or install Times New Roman) so letterhead and body text render correctly]
 
   Note that this template provides proper formatting for various elements via Typst functions. The recipient line uses proper grid formatting, the body uses automatic paragraph numbering, the signature block uses precise positioning, and so on. The template handles all AFH 33-337 formatting requirements automatically.
 

--- a/template/usaf-template.typ
+++ b/template/usaf-template.typ
@@ -30,7 +30,7 @@
 
   - #strong[If you are on the Typst app, upload #text(color.blue)[#link("https://github.com/nibsbin/tonguetoquill-usaf-memo/raw/main/fonts/CopperplateCC/CopperplateCC-Heavy.otf")[Copperplate CC]] to your project folder]
 
-  Note that this template provides proper formatting for various elements via Typst functions. The recipient line uses proper grid formatting, the body uses list/enum for hierarchical subparagraph numbering, the signature block uses precise positioning, and so on. The template handles all AFH 33-337 formatting requirements automatically.
+  Note that this template provides proper formatting for various elements via Typst functions. The recipient line uses proper grid formatting, the body uses automatic paragraph numbering, the signature block uses precise positioning, and so on. The template handles all AFH 33-337 formatting requirements automatically.
 
   Place "MEMORANDUM FOR" on the second line below the date. Leave two spaces between "MEMORANDUM FOR" and the recipient's office symbol. If there are multiple recipients, two or three office symbols may be placed on each line aligned under the entries on the first line. If there are numerous recipients, type "DISTRIBUTION" after "MEMORANDUM FOR" and use a "DISTRIBUTION" element below the signature block.
 


### PR DESCRIPTION
## Summary

This branch adds **DAF (Department of the Air Force) memo** support aligned with **AFH 33-337**, extends letterhead configuration, and updates docs for fonts and usage.

### Highlights
- **DAF memo style**: Fixed paragraph indentation, memo-style date rendering, and template/build integration (`daf-template.typ`).
- **Letterhead**: Optional `letterhead_seal_subtitle`, layout tweaks (bold title, seal/title alignment), uppercase title/caption where required.
- **Typography**: Defaults and docs emphasize **NimbusRomNo9L** for letterhead and body to match Times New Roman; README no longer references Copperplate for this flow.
- **Paragraph numbering**: Prior work on automatic base-level numbering vs. hierarchical list numbering is reflected in the stack; docs/changelog updated for current behavior.

### Files of note
- Template and README updates under `template/`
- Core formatting in `src/` (config, primitives, body rendering as applicable)

Reviewers: please sanity-check PDF output against `pdfs/daf-template.pdf` or a local compile if you have Typst.