### PR TITLE
Rename all public parameters from snake_case to kebab-case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `tonguetoquill-usaf-memo` are documented here.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Breaking: all public parameters renamed from `snake_case` to `kebab-case`** for consistency with Typst idiom. Update call sites as follows:
+  - `frontmatter`: `memo_for` → `memo-for`, `memo_from` → `memo-from`, `letterhead_title` → `letterhead-title`, `letterhead_caption` → `letterhead-caption`, `letterhead_seal` → `letterhead-seal`, `letterhead_seal_subtitle` → `letterhead-seal-subtitle`, `letterhead_font` → `letterhead-font`, `body_font` → `body-font`, `font_size` → `font-size`, `memo_for_cols` → `memo-for-cols`, `classification_level` → `classification-level`, `footer_tag_line` → `footer-tag-line`, `auto_numbering` → `auto-numbering`, `memo_style` → `memo-style`.
+  - `backmatter`: `signature_block` → `signature-block`, `signature_blank_lines` → `signature-blank-lines`, `leading_pagebreak` → `leading-pagebreak`.
+  - `indorsement`: `signature_block` → `signature-block`, `signature_blank_lines` → `signature-blank-lines`.
+
+---
+
 ## [2.0.0] — 2026-03-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ Import the core functions for creating memorandums:
 ```typst
 #show: frontmatter.with(
   subject: "Your Subject Here",
-  memo_for: ("OFFICE/SYMBOL",),
-  memo_from: ("YOUR/SYMBOL",),
+  memo-for: ("OFFICE/SYMBOL",),
+  memo-from: ("YOUR/SYMBOL",),
 )
 
 #show: mainmatter
@@ -108,7 +108,7 @@ Your memorandum content goes here.
 Continue with regular paragraphs.
 
 #backmatter(
-  signature_block: ("NAME, Rank, USAF", "Title"),
+  signature-block: ("NAME, Rank, USAF", "Title"),
 )
 ```
 
@@ -171,12 +171,12 @@ Tables do not count toward paragraph numbering and are rendered between numbered
 
 ### Classification markings
 
-Set `classification_level` in `frontmatter` to display color-coded banners in the page header and footer:
+Set `classification-level` in `frontmatter` to display color-coded banners in the page header and footer:
 
 ```typst
 #show: frontmatter.with(
   // ...
-  classification_level: "SECRET",
+  classification-level: "SECRET",
 )
 ```
 
@@ -194,44 +194,44 @@ Configures the memorandum header and establishes document-wide settings. Applied
 
 **Required Parameters:**
 - `subject`: Memorandum subject line (must be descriptive and in title case)
-- `memo_for`: Recipients (string or array of office symbols)
-- `memo_from`: Sender information (string or array with office symbol, organization, address)
+- `memo-for`: Recipients (string or array of office symbols)
+- `memo-from`: Sender information (string or array with office symbol, organization, address)
 
 **Key Parameters:**
 ```typst
 #show: frontmatter.with(
-  letterhead_title: "DEPARTMENT OF THE AIR FORCE",           // Organization title
-  letterhead_caption: "[YOUR SQUADRON/UNIT NAME]",           // Sub-organization
-  letterhead_seal: none,                                     // Organization seal image
-  letterhead_seal_subtitle: none,                            // Optional line under seal (9pt bold caps)
+  letterhead-title: "DEPARTMENT OF THE AIR FORCE",           // Organization title
+  letterhead-caption: "[YOUR SQUADRON/UNIT NAME]",           // Sub-organization
+  letterhead-seal: none,                                     // Organization seal image
+  letterhead-seal-subtitle: none,                            // Optional line under seal (9pt bold caps)
   date: none,                                                // Date (defaults to today; also accepts ISO string "YYYY-MM-DD")
-  memo_for: ("[OFFICE1]", "[OFFICE2]"),                     // Recipients array
-  memo_from: ("[YOUR/SYMBOL]", "[Organization]", "[Address]"), // Sender info array
+  memo-for: ("[OFFICE1]", "[OFFICE2]"),                     // Recipients array
+  memo-from: ("[YOUR/SYMBOL]", "[Organization]", "[Address]"), // Sender info array
   subject: "[Your Subject in Title Case - Required]",        // Subject line
   references: ("AFI 123-45", "AFMAN 67-89"),                // Optional references
 
   // Styling options
-  letterhead_font: ("times new roman", "NimbusRomNo9L"),   // Letterhead fonts (defaults match body)
-  body_font: ("times new roman", "NimbusRomNo9L"),          // Body fonts
-  font_size: 12pt,                                          // Font size (default 12pt; 10pt minimum per AFH 33-337 §5)
-  memo_for_cols: 3,                                         // Recipient columns
+  letterhead-font: ("times new roman", "NimbusRomNo9L"),   // Letterhead fonts (defaults match body)
+  body-font: ("times new roman", "NimbusRomNo9L"),          // Body fonts
+  font-size: 12pt,                                          // Font size (default 12pt; 10pt minimum per AFH 33-337 §5)
+  memo-for-cols: 3,                                         // Recipient columns
 
   // Classification and branding
-  classification_level: none,                               // e.g. "UNCLASSIFIED", "SECRET", or "TOP SECRET" for standard colors
-  footer_tag_line: none,                                    // Custom footer tagline (e.g., "semper supra")
+  classification-level: none,                               // e.g. "UNCLASSIFIED", "SECRET", or "TOP SECRET" for standard colors
+  footer-tag-line: none,                                    // Custom footer tagline (e.g., "semper supra")
 
   // Paragraph numbering
-  auto_numbering: true,                                     // Automatic AFH 33-337 paragraph numbering (default true)
+  auto-numbering: true,                                     // Automatic AFH 33-337 paragraph numbering (default true)
 )
 ```
 
 **Responsibilities:**
 - Sets page layout with 1-inch margins
-- Renders letterhead with optional seal and optional `letterhead_seal_subtitle` under the seal
+- Renders letterhead with optional seal and optional `letterhead-seal-subtitle` under the seal
 - Renders date, MEMORANDUM FOR, FROM, SUBJECT, and references sections
 - Establishes typography and spacing rules
-- Renders color-coded classification banners in header and footer when `classification_level` is set
-- Renders custom footer tagline when `footer_tag_line` is set
+- Renders color-coded classification banners in header and footer when `classification-level` is set
+- Renders custom footer tagline when `footer-tag-line` is set
 - Stores configuration for downstream sections
 
 #### `mainmatter`
@@ -246,7 +246,7 @@ Processes the memorandum body content with automatic paragraph numbering. Applie
 - Applies AFH 33-337 hierarchical paragraph numbering (1., a., (1), (a))
 - Handles proper indentation and spacing
 - Auto-detects single vs. multiple paragraphs
-- When `auto_numbering: false` is set in `frontmatter`, base-level paragraphs render flush left without numbering; only explicitly bulleted or numbered items (list/enum) receive numbering
+- When `auto-numbering: false` is set in `frontmatter`, base-level paragraphs render flush left without numbering; only explicitly bulleted or numbered items (list/enum) receive numbering
 - Supports inline tables with formal black-border formatting
 - Inherits configuration from frontmatter
 
@@ -257,12 +257,12 @@ Renders the closing section including signature block and optional attachments/c
 **Key Parameters:**
 ```typst
 #backmatter(
-  signature_block: ("[NAME, Rank, USAF]", "[Title]"),      // Signature lines (required)
-  signature_blank_lines: 4,                                // Blank lines above signature
+  signature-block: ("[NAME, Rank, USAF]", "[Title]"),      // Signature lines (required)
+  signature-blank-lines: 4,                                // Blank lines above signature
   attachments: ("Attachment 1", "Attachment 2"),            // Optional attachments
   cc: ("[OFFICE/SYMBOL]",),                                // Courtesy copies
   distribution: ("[OFFICE]",),                             // Distribution list
-  leading_pagebreak: false,                                // Force page break before backmatter
+  leading-pagebreak: false,                                // Force page break before backmatter
 )
 ```
 
@@ -280,8 +280,8 @@ Creates an indorsement for forwarding or commenting on a memorandum. Called as a
 #indorsement(
   from: "ORG/SYMBOL",                                       // Sending organization
   to: "RECIPIENT/SYMBOL",                                   // Recipient organization
-  signature_block: ("[NAME, Rank, USAF]", "[Title]"),      // Signature lines
-  signature_blank_lines: 4,                                // Blank lines above signature
+  signature-block: ("[NAME, Rank, USAF]", "[Title]"),      // Signature lines
+  signature-blank-lines: 4,                                // Blank lines above signature
   attachments: none,                                        // Optional attachments
   cc: none,                                                 // Courtesy copies
   date: datetime.today(),                                  // Indorsement date (also accepts ISO string "YYYY-MM-DD")

--- a/dev_assets/test_multiblock.typ
+++ b/dev_assets/test_multiblock.typ
@@ -2,8 +2,8 @@
 
 #show: frontmatter.with(
   subject: "Test Multi-Block List Items",
-  memo_for: "TEST/CC",
-  memo_from: "TEST/DO",
+  memo-for: "TEST/CC",
+  memo-from: "TEST/DO",
 )
 
 #show: mainmatter

--- a/dev_assets/test_spacing_regression.typ
+++ b/dev_assets/test_spacing_regression.typ
@@ -2,11 +2,11 @@
 
 #show: frontmatter.with(
   subject: "Spacing Regression",
-  memo_for: (
+  memo-for: (
     "TEST/CC",
     "TEST/CD",
   ),
-  memo_from: (
+  memo-from: (
     "TEST/DO",
     "123 Example Street",
     "Washington DC 12345",

--- a/src/backmatter.typ
+++ b/src/backmatter.typ
@@ -10,19 +10,19 @@
 #import "primitives.typ": *
 
 #let backmatter(
-  signature_block: none,
-  signature_blank_lines: 4,
+  signature-block: none,
+  signature-blank-lines: 4,
   attachments: none,
   cc: none,
   distribution: none,
-  leading_pagebreak: false,
+  leading-pagebreak: false,
 ) = {
   // Render backmatter sections without paragraph numbering
-  render-signature-block(signature_block, signature-blank-lines: signature_blank_lines)
+  render-signature-block(signature-block, signature-blank-lines: signature-blank-lines)
   render-backmatter-sections(
     attachments: attachments,
     cc: cc,
     distribution: distribution,
-    leading-pagebreak: leading_pagebreak,
+    leading-pagebreak: leading-pagebreak,
   )
 }

--- a/src/body.typ
+++ b/src/body.typ
@@ -106,28 +106,28 @@
   ITEM_FIRST_PAR.update(false)
 
   // The first pass parses paragraphs, list items, etc. into standardized arrays
-  let first_pass = {
+  let first-pass = {
     // Collect pars with nesting level
     show par: p => context {
-      let nest_level = NEST_DOWN.get().at(0) - NEST_UP.get().at(0)
-      let is_heading = IS_HEADING.get()
-      let is_first_par = ITEM_FIRST_PAR.get()
+      let nest-level = NEST_DOWN.get().at(0) - NEST_UP.get().at(0)
+      let is-heading = IS_HEADING.get()
+      let is-first-par = ITEM_FIRST_PAR.get()
 
       // Determine if this is a continuation block within a multi-block list item.
-      // A continuation is a non-first paragraph inside a list item (nest_level > 0).
-      let is_continuation = nest_level > 0 and not is_first_par
+      // A continuation is a non-first paragraph inside a list item (nest-level > 0).
+      let is-continuation = nest-level > 0 and not is-first-par
 
       PAR_BUFFER.update(pars => {
         pars.push((
           content: text([#p.body]),
-          nest_level: nest_level,
-          kind: if is_heading { "heading" } else if is_continuation { "continuation" } else { "par" },
+          nest-level: nest-level,
+          kind: if is-heading { "heading" } else if is-continuation { "continuation" } else { "par" },
         ))
         pars
       })
 
       // After the first paragraph of a list item, mark subsequent ones as continuations
-      if nest_level > 0 and is_first_par {
+      if nest-level > 0 and is-first-par {
         ITEM_FIRST_PAR.update(false)
       }
 
@@ -138,7 +138,7 @@
       PAR_BUFFER.update(pars => {
         pars.push((
           content: t,
-          nest_level: -1,
+          nest-level: -1,
           kind: "table",
         ))
         pars
@@ -189,20 +189,20 @@
     }
   }
   // Use place() to prevent hidden content from affecting layout flow
-  place(hide(first_pass))
+  place(hide(first-pass))
 
   // Second pass: consume par buffer
   //
   // PAR_BUFFER item dictionary layout:
   //   item.content    — the paragraph body or table element
-  //   item.nest_level — nesting depth (−1 for tables)
+  //   item.nest-level — nesting depth (−1 for tables)
   //   item.kind       — "par", "heading", "table", or "continuation"
   context {
-    let heading_buffer = none
+    let heading-buffer = none
     // Only top-level paragraphs count for AFH 33-337 §2 numbering purposes
-    let par_count = PAR_BUFFER.get().filter(item => item.kind == "par").len()
+    let par-count = PAR_BUFFER.get().filter(item => item.kind == "par").len()
     let items = PAR_BUFFER.get()
-    let total_count = items.len()
+    let total-count = items.len()
 
     // Track paragraph numbers per level manually to avoid nested-context
     // counter propagation issues.  Dictionary maps level index (as string)
@@ -217,91 +217,91 @@
     for item in items {
       i += 1
       let kind = item.kind
-      let item_content = item.content
+      let item-content = item.content
 
       // Buffer headings for prepend to the next rendered element
       if kind == "heading" {
-        heading_buffer = item_content
+        heading-buffer = item-content
         continue
       }
 
       // Prepend buffered heading to the next non-heading element
-      if heading_buffer != none {
+      if heading-buffer != none {
         if kind == "table" {
           // Tables cannot have inline text prepended; emit heading as
           // a standalone bold line above the table
           blank-line()
-          strong[#heading_buffer.]
-          heading_buffer = none
+          strong[#heading-buffer.]
+          heading-buffer = none
         } else {
-          item_content = [#strong[#heading_buffer.] #item_content]
-          heading_buffer = none
+          item-content = [#strong[#heading-buffer.] #item-content]
+          heading-buffer = none
         }
       }
 
       // Format based on element kind
-      let nest_level = item.nest_level
+      let nest-level = item.nest-level
       let indent-fn = if memo-style == "daf" {
         (level, _counts) => calculate-daf-indent(level)
       } else {
         (level, counts) => calculate-indent-from-counts(level, counts)
       }
-      let final_par = {
+      let final-par = {
         if kind == "table" {
-          render-memo-table(item_content)
+          render-memo-table(item-content)
         } else if kind == "continuation" {
           // Continuation block within a multi-block list item:
           // indent to align with preceding numbered paragraph's text, no new number.
           // level-counts still holds the value of the preceding numbered paragraph.
           if memo-style == "daf" {
-            if nest_level > 0 {
-              format-par(item_content, nest_level, level-counts, indent-fn, continuation: true)
+            if nest-level > 0 {
+              format-par(item-content, nest-level, level-counts, indent-fn, continuation: true)
             } else {
-              item_content
+              item-content
             }
           } else if auto-numbering {
-            format-par(item_content, nest_level, level-counts, indent-fn, continuation: true)
-          } else if nest_level > 0 {
-            format-par(item_content, nest_level - 1, level-counts, indent-fn, continuation: true)
+            format-par(item-content, nest-level, level-counts, indent-fn, continuation: true)
+          } else if nest-level > 0 {
+            format-par(item-content, nest-level - 1, level-counts, indent-fn, continuation: true)
           } else {
-            item_content
+            item-content
           }
         } else if memo-style == "daf" {
-          if nest_level > 0 {
-            let par = format-par(item_content, nest_level, level-counts, indent-fn)
-            level-counts.insert(str(nest_level), level-counts.at(str(nest_level), default: 1) + 1)
-            level-counts = reset-levels-from(level-counts, nest_level + 1, max-levels)
+          if nest-level > 0 {
+            let par = format-par(item-content, nest-level, level-counts, indent-fn)
+            level-counts.insert(str(nest-level), level-counts.at(str(nest-level), default: 1) + 1)
+            level-counts = reset-levels-from(level-counts, nest-level + 1, max-levels)
             par
           } else {
             // DAF top-level paragraphs are unnumbered and first-line indented.
             // Reset nested counters so each new top-level paragraph restarts children.
             level-counts = reset-levels-from(level-counts, 0, max-levels)
-            [#h(daf-paragraph.top-first-line-indent)#item_content]
+            [#h(daf-paragraph.top-first-line-indent)#item-content]
           }
         } else if auto-numbering {
-          if par_count > 1 {
+          if par-count > 1 {
             // Apply paragraph numbering per AFH 33-337 §2
-            let par = format-par(item_content, nest_level, level-counts, indent-fn)
-            level-counts.insert(str(nest_level), level-counts.at(str(nest_level)) + 1)
-            level-counts = reset-levels-from(level-counts, nest_level + 1, max-levels)
+            let par = format-par(item-content, nest-level, level-counts, indent-fn)
+            level-counts.insert(str(nest-level), level-counts.at(str(nest-level)) + 1)
+            level-counts = reset-levels-from(level-counts, nest-level + 1, max-levels)
             par
           } else {
             // AFH 33-337 §2: "A single paragraph is not numbered"
-            item_content
+            item-content
           }
         } else {
           // Unnumbered mode: only explicitly nested items (enum/list) get numbered
-          if nest_level > 0 {
-            let effective_level = nest_level - 1
-            let par = format-par(item_content, effective_level, level-counts, indent-fn)
-            level-counts.insert(str(effective_level), level-counts.at(str(effective_level)) + 1)
-            level-counts = reset-levels-from(level-counts, effective_level + 1, max-levels)
+          if nest-level > 0 {
+            let effective-level = nest-level - 1
+            let par = format-par(item-content, effective-level, level-counts, indent-fn)
+            level-counts.insert(str(effective-level), level-counts.at(str(effective-level)) + 1)
+            level-counts = reset-levels-from(level-counts, effective-level + 1, max-levels)
             par
           } else {
             // Base-level paragraphs are flush left with no numbering.
             // Reset all child level counters so subsequent list items restart at 1.
             level-counts = reset-levels-from(level-counts, 0, max-levels)
-            item_content
+            item-content
           }
         }
       }
@@ -309,11 +309,11 @@
       // If this is the final item, apply AFH 33-337 §11 rule:
       // "Avoid dividing a paragraph of less than four lines between two pages"
       blank-line()
-      if i == total_count {
-        let available_width = page.width - spacing.margin * 2
+      if i == total-count {
+        let available-width = page.width - spacing.margin * 2
 
         // Use the shared measured line stride used by blank-line spacing.
-        let line_height = {
+        let line-height = {
           let cached = LINE_STRIDE.get()
           if cached != none {
             cached
@@ -323,19 +323,19 @@
           }
         }
         // Calculate last item's height
-        let par_height = measure(final_par, width: available_width).height
+        let par-height = measure(final-par, width: available-width).height
 
-        let estimated_lines = calc.ceil(par_height / line_height)
+        let estimated-lines = calc.ceil(par-height / line-height)
 
-        if estimated_lines < 4 {
+        if estimated-lines < 4 {
           // Short content (< 4 lines): make sticky to keep with signature
-          block(sticky: true)[#final_par]
+          block(sticky: true)[#final-par]
         } else {
           // Longer content (≥ 4 lines): use default breaking behavior
-          block(breakable: true)[#final_par]
+          block(breakable: true)[#final-par]
         }
       } else {
-        final_par
+        final-par
       }
     }
   }

--- a/src/frontmatter.typ
+++ b/src/frontmatter.typ
@@ -11,39 +11,39 @@
 
 #let frontmatter(
   subject: none,
-  memo_for: none,
-  memo_from: none,
+  memo-for: none,
+  memo-from: none,
   date: none,
   references: none,
-  letterhead_title: "DEPARTMENT OF THE AIR FORCE",
-  letterhead_caption: "[YOUR SQUADRON/UNIT NAME]",
-  letterhead_seal: none,
-  letterhead_seal_subtitle: none, // optional line under seal (9pt bold caps); ignored if no seal
-  letterhead_font: DEFAULT_LETTERHEAD_FONTS,
-  body_font: DEFAULT_BODY_FONTS,
-  font_size: 12pt,
-  memo_for_cols: 3,
-  classification_level: none,
-  footer_tag_line: none,
-  auto_numbering: true,
-  memo_style: "usaf",
+  letterhead-title: "DEPARTMENT OF THE AIR FORCE",
+  letterhead-caption: "[YOUR SQUADRON/UNIT NAME]",
+  letterhead-seal: none,
+  letterhead-seal-subtitle: none, // optional line under seal (9pt bold caps); ignored if no seal
+  letterhead-font: DEFAULT_LETTERHEAD_FONTS,
+  body-font: DEFAULT_BODY_FONTS,
+  font-size: 12pt,
+  memo-for-cols: 3,
+  classification-level: none,
+  footer-tag-line: none,
+  auto-numbering: true,
+  memo-style: "usaf",
   it,
 ) = {
   assert(subject != none, message: "subject is required")
-  assert(memo_for != none, message: "memo_for is required")
-  assert(memo_from != none, message: "memo_from is required")
+  assert(memo-for != none, message: "memo-for is required")
+  assert(memo-from != none, message: "memo-from is required")
   assert(
-    memo_style in ("usaf", "daf"),
-    message: "memo_style must be \"usaf\" or \"daf\"",
+    memo-style in ("usaf", "daf"),
+    message: "memo-style must be \"usaf\" or \"daf\"",
   )
 
-  let actual_date = if date == none { datetime.today() } else { date }
-  let classification_color = get-classification-level-color(classification_level)
+  let actual-date = if date == none { datetime.today() } else { date }
+  let classification-color = get-classification-level-color(classification-level)
 
   // Document-wide typography settings (inlined from configure())
   set par(leading: spacing.line, spacing: spacing.line, justify: false)
   set block(above: spacing.line, below: 0em, spacing: 0em)
-  set text(font: body_font, size: font_size, fallback: true)
+  set text(font: body-font, size: font-size, fallback: true)
 
   set page(
     paper: "us-letter",
@@ -68,11 +68,11 @@
         )
       }
 
-      if classification_level != none {
+      if classification-level != none {
         place(
           top + center,
           dy: 0.375in,
-          text(12pt, font: DEFAULT_BODY_FONTS, fill: classification_color)[#strong(classification_level)],
+          text(12pt, font: DEFAULT_BODY_FONTS, fill: classification-color)[#strong(classification-level)],
         )
       }
     },
@@ -80,15 +80,15 @@
       place(
         bottom + center,
         dy: -.375in,
-        text(12pt, font: DEFAULT_BODY_FONTS, fill: classification_color)[#strong(classification_level)],
+        text(12pt, font: DEFAULT_BODY_FONTS, fill: classification-color)[#strong(classification-level)],
       )
 
-      if not falsey(footer_tag_line) {
+      if not falsey(footer-tag-line) {
         place(
           bottom + center,
           dy: -0.625in,
           align(center)[
-            #text(fill: LETTERHEAD_COLOR, font: "cinzel", size: 15pt)[#footer_tag_line]
+            #text(fill: LETTERHEAD_COLOR, font: "cinzel", size: 15pt)[#footer-tag-line]
           ],
         )
       }
@@ -96,11 +96,11 @@
   )
 
   render-letterhead(
-    letterhead_title,
-    letterhead_caption,
-    letterhead_font,
-    letterhead-seal: letterhead_seal,
-    letterhead-seal-subtitle: letterhead_seal_subtitle,
+    letterhead-title,
+    letterhead-caption,
+    letterhead-font,
+    letterhead-seal: letterhead-seal,
+    letterhead-seal-subtitle: letterhead-seal-subtitle,
   )
 
   // AFH 33-337 "Date": "Place the date 1 inch from the right edge, 1.75 inches from the top"
@@ -119,17 +119,17 @@
 
   metadata((
     subject: subject,
-    original_date: actual_date,
-    original_from: first-or-value(memo_from),
-    body_font: body_font,
-    font_size: font_size,
-    auto_numbering: auto_numbering,
-    memo_style: memo_style,
+    original-date: actual-date,
+    original-from: first-or-value(memo-from),
+    body-font: body-font,
+    font-size: font-size,
+    auto-numbering: auto-numbering,
+    memo-style: memo-style,
   ))
 
-  render-date-section(actual_date, memo-style: memo_style)
-  render-for-section(memo_for, memo_for_cols)
-  render-from-section(memo_from)
+  render-date-section(actual-date, memo-style: memo-style)
+  render-for-section(memo-for, memo-for-cols)
+  render-from-section(memo-from)
   render-subject-section(subject)
   render-references-section(references)
 

--- a/src/indorsement.typ
+++ b/src/indorsement.typ
@@ -16,8 +16,8 @@
 #let indorsement(
   from: none,
   to: none,
-  signature_block: none,
-  signature_blank_lines: 4,
+  signature-block: none,
+  signature-blank-lines: 4,
   attachments: none,
   cc: none,
   date: none,
@@ -41,9 +41,9 @@
   }
 
 
-  let actual_date = if date == none { datetime.today() } else { date }
-  let ind_from = first-or-value(from)
-  let ind_for = to
+  let actual-date = if date == none { datetime.today() } else { date }
+  let ind-from = first-or-value(from)
+  let ind-for = to
 
   if format != "informal" {
     // Step the counter BEFORE the context block to avoid read-then-update loop
@@ -51,41 +51,41 @@
 
     context {
       let config = query(metadata).last().value
-      let memo-style = config.at("memo_style", default: "usaf")
-      let original_subject = config.subject
-      let original_date = config.original_date
-      let original_from = config.original_from
+      let memo-style = config.at("memo-style", default: "usaf")
+      let original-subject = config.subject
+      let original-date = config.at("original-date")
+      let original-from = config.at("original-from")
 
       // Read the counter value (already stepped above)
-      let indorsement_number = counters.indorsement.get().at(0, default: 1)
-      let indorsement_label = format-indorsement-number(indorsement_number)
+      let indorsement-number = counters.indorsement.get().at(0, default: 1)
+      let indorsement-label = format-indorsement-number(indorsement-number)
 
       if format == "separate_page" {
         pagebreak()
-        [#indorsement_label to #original_from, #display-date(original_date, memo-style: memo-style), #original_subject]
+        [#indorsement-label to #original-from, #display-date(original-date, memo-style: memo-style), #original-subject]
 
         blank-line()
         grid(
           columns: (auto, 1fr),
-          ind_from, align(right)[#display-date(actual_date, memo-style: memo-style)],
+          ind-from, align(right)[#display-date(actual-date, memo-style: memo-style)],
         )
 
         blank-line()
         grid(
           columns: (auto, auto, 1fr),
-          "MEMORANDUM FOR", "  ", ind_for,
+          "MEMORANDUM FOR", "  ", ind-for,
         )
       } else {
         blank-line()
         grid(
           columns: (auto, 1fr),
-          [#indorsement_label, #ind_from], align(right)[#display-date(actual_date, memo-style: memo-style)],
+          [#indorsement-label, #ind-from], align(right)[#display-date(actual-date, memo-style: memo-style)],
         )
 
         blank-line()
         grid(
           columns: (auto, auto, 1fr),
-          "MEMORANDUM FOR", "  ", ind_for,
+          "MEMORANDUM FOR", "  ", ind-for,
         )
       }
     }
@@ -100,12 +100,12 @@
   context {
     let memo-style = {
       let items = query(metadata)
-      if items.len() > 0 { items.last().value.at("memo_style", default: "usaf") } else { "usaf" }
+      if items.len() > 0 { items.last().value.at("memo-style", default: "usaf") } else { "usaf" }
     }
     render-body(content, memo-style: memo-style)
   }
 
-  render-signature-block(signature_block, signature-blank-lines: signature_blank_lines)
+  render-signature-block(signature-block, signature-blank-lines: signature-blank-lines)
 
   render-backmatter-sections(attachments: attachments, cc: cc)
 }

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -26,9 +26,9 @@
 //
 // #show: frontmatter.with(
 //   subject: "Your Subject Here",
-//   memo_for: ("OFFICE/SYMBOL",),
-//   memo_from: ("YOUR/SYMBOL",),
-//   memo_style: "usaf", // "usaf" (default) or "daf"
+//   memo-for: ("OFFICE/SYMBOL",),
+//   memo-from: ("YOUR/SYMBOL",),
+//   memo-style: "usaf", // "usaf" (default) or "daf"
 // )
 //
 // #show: mainmatter
@@ -38,7 +38,7 @@
 // top-level paragraphs with fixed 0.5in first-line indentation)
 //
 // #backmatter(
-//   signature_block: ("NAME, Rank, USAF", "Title"),
+//   signature-block: ("NAME, Rank, USAF", "Title"),
 //   attachments: (...),
 //   cc: (...),
 // )
@@ -46,7 +46,7 @@
 // #indorsement(
 //   from: "ORG/SYMBOL",
 //   to: "RECIPIENT/SYMBOL",
-//   signature_block: ("NAME, Rank, USAF", "Title"),
+//   signature-block: ("NAME, Rank, USAF", "Title"),
 // )[
 //   Indorsement content here.
 // ]

--- a/src/mainmatter.typ
+++ b/src/mainmatter.typ
@@ -18,7 +18,7 @@
 /// of the memorandum. Automatically detects single vs. multiple paragraphs
 /// to comply with AFH 33-337 numbering requirements.
 ///
-/// When `auto_numbering` is false (set in frontmatter), base-level paragraphs
+/// When `auto-numbering` is false (set in frontmatter), base-level paragraphs
 /// render flush left without numbering. Only explicitly numbered or bulleted
 /// items enter the numbering hierarchy.
 ///
@@ -26,7 +26,7 @@
 /// -> content
 #let mainmatter(it) = context {
   let config = query(metadata).last().value
-  let auto-numbering = config.at("auto_numbering", default: true)
-  let memo-style = config.at("memo_style", default: "usaf")
+  let auto-numbering = config.at("auto-numbering", default: true)
+  let memo-style = config.at("memo-style", default: "usaf")
   render-body(it, auto-numbering: auto-numbering, memo-style: memo-style)
 }

--- a/src/primitives.typ
+++ b/src/primitives.typ
@@ -52,8 +52,8 @@
         #fit-box(width: 2in, height: 1in)[#letterhead-seal]
       ]
     } else {
-      // Isolate seal column from document `font_size`: stack `em` spacing and subtitle
-      // must not scale with body text (see frontmatter `set text(size: font_size)`).
+      // Isolate seal column from document `font-size`: stack `em` spacing and subtitle
+      // must not scale with body text (see frontmatter `set text(size: font-size)`).
       block(width: 2in)[
         #set text(9pt, font: font, fill: LETTERHEAD_COLOR, weight: "bold")
         #align(left)[
@@ -276,8 +276,8 @@
 
 #let calculate-backmatter-spacing(is-first-section) = {
   context {
-    let line_count = if is-first-section { 2 } else { 1 }
-    blank-lines(line_count)
+    let line-count = if is-first-section { 2 } else { 1 }
+    blank-lines(line-count)
   }
 }
 

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -164,17 +164,17 @@
 /// - cols (int): Number of columns for the grid (default: 3)
 /// -> grid
 #let create-auto-grid(content, column-gutter: .5em, cols: 3) = {
-  let content_type = type(content)
+  let content-type = type(content)
 
-  assert(content_type == str or content_type == array, message: "Content must be a string or an array of strings.")
-  if content_type == array {
+  assert(content-type == str or content-type == array, message: "Content must be a string or an array of strings.")
+  if content-type == array {
     for item in content {
       assert(type(item) == str, message: "All items in content array must be strings.")
     }
   }
 
   // Normalize to 1d array
-  if content_type == str {
+  if content-type == str {
     content = (content,)
   }
 
@@ -194,8 +194,8 @@
   // Add padding cells to complete the last row if needed
   let remainder = calc.rem(cells.len(), cols + 1)
   if remainder != 0 {
-    let padding_needed = (cols + 1) - remainder
-    for _ in range(padding_needed) {
+    let padding-needed = (cols + 1) - remainder
+    for _ in range(padding-needed) {
       cells.push([])
     }
   }

--- a/template/daf-template.typ
+++ b/template/daf-template.typ
@@ -1,20 +1,20 @@
 #import "@preview/tonguetoquill-usaf-memo:3.0.0": backmatter, frontmatter, mainmatter
 
 #show: frontmatter.with(
-  letterhead_title: "DEPARTMENT OF THE AIR FORCE",
-  letterhead_caption: "washington, DC",
-  letterhead_seal: image("assets/dow_seal.png"),
-  letterhead_seal_subtitle: "Office of the Secretary",
+  letterhead-title: "DEPARTMENT OF THE AIR FORCE",
+  letterhead-caption: "washington, DC",
+  letterhead-seal: image("assets/dow_seal.png"),
+  letterhead-seal-subtitle: "Office of the Secretary",
   date: datetime(month:1,day:1,year:2024),
   subject: "Format for the Official Memorandum",
-  memo_for: "XXXX",
-  memo_from: (
+  memo-for: "XXXX",
+  memo-from: (
     "SAF/CN",
     "1800 Air Force Pentagon",
     "Washington, D.C., 20330-1665",
   ),
   references: ("HOI 33-3, Correspondence Preparation, Control, and Tracking",),
-  memo_style: "daf",
+  memo-style: "daf",
 )
 
 #mainmatter[
@@ -30,7 +30,7 @@
 ]
 
 #backmatter(
-  signature_block: (
+  signature-block: (
     "VENICE M. GOODWINE, SES, DAF",
     "Chief Information Officer",
   ),

--- a/template/starkindustries.typ
+++ b/template/starkindustries.typ
@@ -1,16 +1,16 @@
 #import "@preview/tonguetoquill-usaf-memo:3.0.0": backmatter, frontmatter, mainmatter
 
 #show: frontmatter.with(
-  letterhead_title: "STARK INDUSTRIES",
-  letterhead_caption: "EXECUTIVE OFFICE",
-  letterhead_seal: image("assets/starkindustries_seal.png"),
+  letterhead-title: "STARK INDUSTRIES",
+  letterhead-caption: "EXECUTIVE OFFICE",
+  letterhead-seal: image("assets/starkindustries_seal.png"),
   subject: "Immediate Compliance Required: Unauthorized Flight Operations and Workplace Safety Violations",
-  memo_for: (
+  memo-for: (
     "MR. ANTHONY E. STARK, CEO",
     "STARK INDUSTRIES",
   ),
-  memo_for_cols: 1,
-  memo_from: (
+  memo-for-cols: 1,
+  memo-from: (
     "STARK INDUSTRIES",
     "Executive Office",
     "10880 Malibu Point",
@@ -24,8 +24,8 @@
     "USAF Aircraft Accident Investigation Report, F-22 Raptor Incidents, Classified",
     "Coulson, P., SHIELD Intelligence Brief, 'Unidentified Flying Objects Over Malibu",
   ),
-  footer_tag_line: "Peace Through Power",
-  classification_level: "CONFIDENTIAL",
+  footer-tag-line: "Peace Through Power",
+  classification-level: "CONFIDENTIAL",
 )
 
 #mainmatter[
@@ -79,7 +79,7 @@
   Also, please remind DUM-E that government inspectors are not appropriate targets for fire extinguisher practice, regardless of how "suspicious" they appear.
 ]
 #backmatter(
-  signature_block: (
+  signature-block: (
     "VIRGINIA E. POTTS",
     "Executive Assistant to the CEO",
     "Stark Industries",

--- a/template/usaf-template.typ
+++ b/template/usaf-template.typ
@@ -1,11 +1,11 @@
 #import "@preview/tonguetoquill-usaf-memo:3.0.0": backmatter, frontmatter, indorsement, mainmatter
 
 #show: frontmatter.with(
-  letterhead_title: "DEPARTMENT OF THE AIR FORCE",
-  letterhead_caption: "123RD EXAMPLE SQUADRON",
-  letterhead_seal: image("assets/dow_seal.png"),
+  letterhead-title: "DEPARTMENT OF THE AIR FORCE",
+  letterhead-caption: "123RD EXAMPLE SQUADRON",
+  letterhead-seal: image("assets/dow_seal.png"),
   subject: "Format for the Official Memorandum",
-  memo_for: (
+  memo-for: (
     "123 ES/CC",
     "123 ES/DO",
     "123 ES/CSS",
@@ -13,7 +13,7 @@
     "456 ES/DO",
     "456 ES/CSS",
   ),
-  memo_from: (
+  memo-from: (
     "ORG/SYMBOL",
     "Organization",
     "Street Address",
@@ -78,7 +78,7 @@
 ]
 
 #backmatter(
-  signature_block: (
+  signature-block: (
     "FIRST M. LAST, Rank, USAF",
     "Duty Title",
   ),
@@ -98,7 +98,7 @@
   from: "ORG/SYMBOL [Office symbol for 1st Indorsement Official]",
   to: "ORG/SYMBOL [Office symbol for 2d Indorsement official]",
   action: "approve",
-  signature_block: (
+  signature-block: (
     "FIRST M LAST, Rank, USAF",
     "Duty Title",
   ),
@@ -109,7 +109,7 @@
 #indorsement(
   from: "[Indorser ORG/SYMBOL]",
   to: "ORG/SYMBOL [Originator]",
-  signature_block: (
+  signature-block: (
     "FIRST M LAST, Rank, USAF",
     "Duty Title",
   ),

--- a/template/ussf-template.typ
+++ b/template/ussf-template.typ
@@ -1,18 +1,18 @@
 #import "@preview/tonguetoquill-usaf-memo:3.0.0": backmatter, frontmatter, mainmatter
 
 #show: frontmatter.with(
-  letterhead_title: "DEPARTMENT OF THE SPACE FORCE",
-  letterhead_caption: "1ST SPACE OPERATIONS SQUADRON",
-  letterhead_seal: image("assets/dow_seal.png"),
+  letterhead-title: "DEPARTMENT OF THE SPACE FORCE",
+  letterhead-caption: "1ST SPACE OPERATIONS SQUADRON",
+  letterhead-seal: image("assets/dow_seal.png"),
   subject: "Space Force Memorandum Template Format",
-  memo_for: "SPACECOM/CC",
-  memo_from: (
+  memo-for: "SPACECOM/CC",
+  memo-from: (
     "1 SOPS/CC",
     "1st Space Operations Squadron",
     "Schriever Space Force Base",
     "Colorado Springs CO 80912-7001",
   ),
-  footer_tag_line: "semper supra",
+  footer-tag-line: "semper supra",
 )
 
 #mainmatter[
@@ -28,7 +28,7 @@
 ]
 
 #backmatter(
-  signature_block: (
+  signature-block: (
     "JOHN A. GUARDIAN, Colonel, USSF",
     "Commander",
     "1st Space Operations Squadron",


### PR DESCRIPTION
## Summary

This is a breaking change that standardizes all public API parameters to use kebab-case naming convention, which is idiomatic in Typst. All function signatures, call sites, documentation, and examples have been updated accordingly.

## Key Changes

- **frontmatter()**: Renamed 14 parameters
  - `memo_for` → `memo-for`
  - `memo_from` → `memo-from`
  - `letterhead_title` → `letterhead-title`
  - `letterhead_caption` → `letterhead-caption`
  - `letterhead_seal` → `letterhead-seal`
  - `letterhead_seal_subtitle` → `letterhead-seal-subtitle`
  - `letterhead_font` → `letterhead-font`
  - `body_font` → `body-font`
  - `font_size` → `font-size`
  - `memo_for_cols` → `memo-for-cols`
  - `classification_level` → `classification-level`
  - `footer_tag_line` → `footer-tag-line`
  - `auto_numbering` → `auto-numbering`
  - `memo_style` → `memo-style`

- **backmatter()**: Renamed 3 parameters
  - `signature_block` → `signature-block`
  - `signature_blank_lines` → `signature-blank-lines`
  - `leading_pagebreak` → `leading-pagebreak`

- **indorsement()**: Renamed 2 parameters
  - `signature_block` → `signature-block`
  - `signature_blank_lines` → `signature-blank-lines`

- Updated all internal variable names from snake_case to kebab-case for consistency
- Updated all template examples and documentation to reflect new parameter names
- Added CHANGELOG entry documenting the breaking change

## Implementation Details

- Internal variable renaming was applied throughout `src/body.typ`, `src/frontmatter.typ`, `src/backmatter.typ`, `src/indorsement.typ`, `src/utils.typ`, and `src/primitives.typ`
- All template files (`template/*.typ`) and test files (`dev_assets/*.typ`) updated with new parameter names
- README.md comprehensively updated with all new parameter names in code examples and documentation
- No functional changes to logic or behavior—purely a naming convention update

https://claude.ai/code/session_0117So78X6xNE59yShftm2fT